### PR TITLE
Added id when constructing payload in publishPublicClaim

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -275,7 +275,7 @@ export class IAM extends IAMBase {
         didAttribute: DIDAttribute.ServicePoint,
         data: {
           type: PubKeyType.VerificationKey2018,
-          value: { serviceEndpoint: url, hash: hashes.SHA256(token), hashAlg: "SHA256" }
+          value: { id: uuid(), serviceEndpoint: url, hash: hashes.SHA256(token), hashAlg: "SHA256" }
         }
       });
       return url;


### PR DESCRIPTION
Allows user to add claim which is uniquely resolvable when using `publishPublicClaim`. Providing the service endpoint id allows the resolver to provide all endpoints when building did doc.
