### PR TITLE
Adding tslib as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19637,10 +19637,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -19649,6 +19648,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "js-sha3": "^0.8.0",
     "lodash.difference": "^4.5.0",
     "nats.ws": "^1.0.0-111",
+    "tslib": "^2.0.3",
     "uuid": "^7.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
tslib provides runtime helper functions that will be referenced in transpiled code
Needed because the --importHelpers tsconfig flag is used.

Switchboard, for example, has it installed as a dependency: https://github.com/energywebfoundation/switchboard-dapp/blob/62fe762081082064bb6c03069220d98d6f261c03/package.json#L104