### PR TITLE
[MYEN-515] simplify ownership transfer

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -113,8 +113,8 @@ export class IAM extends IAMBase {
       useMetamaskExtension,
       reinitializeMetamask
     }: { useMetamaskExtension: boolean; reinitializeMetamask?: boolean } = {
-      useMetamaskExtension: false
-    }
+        useMetamaskExtension: false
+      }
   ): Promise<InitializeData> {
     try {
       await this.init({
@@ -652,8 +652,8 @@ export class IAM extends IAMBase {
     const apps = this._cacheClient
       ? await this.getAppsByOrgNamespace({ namespace })
       : await this.getSubdomains({
-          domain: `${ENSNamespaceTypes.Application}.${namespace}`
-        });
+        domain: `${ENSNamespaceTypes.Application}.${namespace}`
+      });
     if (apps && apps.length > 0) {
       throw new Error("You are not able to change ownership of organization with registered apps");
     }
@@ -722,15 +722,14 @@ export class IAM extends IAMBase {
     if (notOwnedNamespaces.length > 0) {
       throw new ChangeOwnershipNotPossibleError({ namespace, notOwnedNamespaces });
     }
-    const [label, ...rest] = namespace.split(".");
     const steps: { next: () => Promise<void>; info: string }[] = [
       {
-        next: () => this.changeSubdomainOwner({ newOwner, namespace: rest.join("."), label }),
+        next: () => this.changeDomainOwner({ newOwner, namespace }),
         info: `Changing ownership of ${namespace}`
       },
       {
         next: () =>
-          this.changeSubdomainOwner({ newOwner, namespace, label: ENSNamespaceTypes.Roles }),
+          this.changeDomainOwner({ newOwner, namespace: `${ENSNamespaceTypes.Roles}.${namespace}` }),
         info: `Changing ownership of ${ENSNamespaceTypes.Roles}.${namespace}`
       }
     ];
@@ -739,9 +738,8 @@ export class IAM extends IAMBase {
     for (const role of roles) {
       steps.push({
         next: () =>
-          this.changeSubdomainOwner({
-            label: role,
-            namespace: `${ENSNamespaceTypes.Roles}.${namespace}`,
+          this.changeDomainOwner({
+            namespace: `${role}.${ENSNamespaceTypes.Roles}.${namespace}`,
             newOwner
           }),
         info: `Changing ownership of ${role}.${ENSNamespaceTypes.Roles}.${namespace}`
@@ -800,8 +798,8 @@ export class IAM extends IAMBase {
     const apps = this._cacheClient
       ? await this.getAppsByOrgNamespace({ namespace })
       : await this.getSubdomains({
-          domain: `${ENSNamespaceTypes.Application}.${namespace}`
-        });
+        domain: `${ENSNamespaceTypes.Application}.${namespace}`
+      });
     if (apps && apps.length > 0) {
       throw new Error("You are not able to remove organization with registered apps");
     }
@@ -1104,9 +1102,8 @@ export class IAM extends IAMBase {
         return owner === this._address ? [] : [parentDomain.join(".")];
       }
       if (type === ENSNamespaceTypes.Application) {
-        const [, ...appsNamespace] = namespace.split(".");
         const appRolesNamespace = `${ENSNamespaceTypes.Roles}.${namespace}`;
-        const namespaces = [namespace, appsNamespace.join("."), appRolesNamespace];
+        const namespaces = [namespace, appRolesNamespace];
         const notOwnedNamespaces = await Promise.all(
           namespaces
             .map(async namespace => {

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -414,6 +414,23 @@ export class IAMBase {
     await tx.wait();
   }
 
+  protected async changeDomainOwner({ newOwner, namespace }: { newOwner: string, namespace: string }) {
+    if (!this._ensRegistry) {
+      throw new ENSRegistryNotInitializedError();
+    }
+    if (!this._signer) {
+      throw new Error("Signer not initialized");
+    }
+    const ensRegistryWithSigner = this._ensRegistry.connect(this._signer);
+    const namespaceHash = namehash(namespace);
+    const tx = await ensRegistryWithSigner.setOwner(
+      namespaceHash,
+      newOwner,
+      this._transactionOverrides
+    );
+    await tx.wait();
+  }
+
   protected async getFilteredDomainsFromEvent({ domain }: { domain: string }) {
     if (this._ensResolver && this._provider) {
       const ensInterface = new Interface(ensResolverContract);

--- a/test/application.testSuite.ts
+++ b/test/application.testSuite.ts
@@ -1,8 +1,9 @@
-import { ENSNamespaceTypes } from "../src/iam";
-import { iam, root } from './iam.test';
+import { ENSNamespaceTypes, IAM } from "../src/iam";
+import { iam, root, rootOwner } from './iam.test';
 import { org1 } from './organization.testSuite';
-import { ensResolver } from "./setup_contracts";
+import { ensResolver, ensRegistry, didContract, replenish } from "./setup_contracts";
 import { namehash } from "ethers/utils";
+import { Keys } from "@ew-did-registry/keys";
 
 export const appsTests = () => {
   const app = 'app1';
@@ -20,6 +21,40 @@ export const appsTests = () => {
     expect(await iam.checkExistenceOfDomain({ domain: `${ENSNamespaceTypes.Roles}.${appNode}` })).toBe(true);
     expect(await ensResolver.name(namehash(appNode))).toBe(appNode);
     expect(await iam.getSubdomains({ domain: `${ENSNamespaceTypes.Application}.${org1}.${root}` })).toContain(app);
+  });
+
+  test('application owner can be changed', async () => {
+    const newOwner = new Keys();
+    await replenish(newOwner.getAddress());
+    const newOwnerIam = new IAM({
+      rpcUrl: 'http://localhost:8544/',
+      chainId: 9,
+      ensRegistryAddress: ensRegistry.address,
+      ensResolverAddress: ensResolver.address,
+      didContractAddress: didContract.address,
+      privateKey: newOwner.privateKey
+    });
+    await newOwnerIam.initializeConnection({
+      useMetamaskExtension: false,
+      reinitializeMetamask: false
+    });
+
+    expect(await iam.isOwner({ domain: appNode, user: rootOwner.getAddress() }));
+
+    await iam.changeAppOwnership({
+      namespace: appNode,
+      newOwner: newOwner.getAddress()
+    });
+
+    expect(await iam.isOwner({ domain: appNode, user: newOwner.getAddress() }));
+    console.log('app owner changed to new owner');
+
+    await newOwnerIam.changeAppOwnership({
+      namespace: appNode,
+      newOwner: rootOwner.getAddress()
+    });
+
+    expect(await iam.isOwner({ domain: appNode, user: rootOwner.getAddress() }));
   });
 
   test('application can be deleted', async () => {

--- a/test/utils/isBrowser.test.ts
+++ b/test/utils/isBrowser.test.ts
@@ -1,7 +1,7 @@
 import { isBrowser } from '../../src/utils/isBrowser';
 
 describe("isBrowser Test", () => {
-  it('returns false if running in node', () => {
+  it('returns true if running in browser', () => {
     const result = isBrowser();
     expect(result).toBe(true);
   });


### PR DESCRIPTION
iam-client-lib does not allow transferring ownership of the top-level node that you own, because transferring the node requires ownership of the parent node. This PR proposes to remove the parent node ownership restriction
- [x] Exclude parent organization from ownership validation and transferring of application

To discuss: these changes allows owner of application not to be owner of app parent organization. Is this consistent with business requirements? Should similar approach be implemented for organization and role transferring?