### PR TITLE
bug/null chain id

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -84,11 +84,13 @@ export class IAM extends IAMBase {
   static async isMetamaskExtensionPresent() {
     const provider = (await detectEthereumProvider({ mustBeMetaMask: true })) as
       | {
-          chainId?: string;
-        }
+        request: any;
+      }
       | undefined;
-    const metamaskChainId = parseInt(provider?.chainId || "", 16);
-    return metamaskChainId === VOLTA_CHAIN_ID;
+    const chainId = await provider?.request({
+      method: 'eth_chainId'
+    });
+    return parseInt(chainId, 16) === VOLTA_CHAIN_ID;
   }
   // GETTERS
 


### PR DESCRIPTION
As `provider.chainId` of injected `window.ethereum` is non-standard property (https://docs.metamask.io/guide/ethereum-provider.html#legacy-properties) chainId detection is changed by recommended method