### PR TITLE
Use NPM_TOKEN env var to fix npm publishing

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,7 @@
       "channel": "latest"
     },
     {
-      "name": "fix/npm-publishing",
+      "name": "develop",
       "prerelease": "alpha",
       "channel": "canary"
     }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,11 +5,6 @@
       "channel": "latest"
     },
     {
-      "name": "develop",
-      "prerelease": "alpha",
-      "channel": "canary"
-    },
-    {
       "name": "fix/npm-publishing",
       "prerelease": "alpha",
       "channel": "canary"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,6 +8,11 @@
       "name": "develop",
       "prerelease": "alpha",
       "channel": "canary"
+    },
+    {
+      "name": "fix/npm-publishing",
+      "prerelease": "alpha",
+      "channel": "canary"
     }
   ],
   "repositoryUrl": "git@github.com:energywebfoundation/iam-client-lib.git",

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,9 @@ deploy:
       script: 'npx semantic-release'
       skip_cleanup: true
       on:
+          branch: fix/npm-publishing
+    - provider: script
+      script: 'npx semantic-release'
+      skip_cleanup: true
+      on:
           branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,4 @@ deploy:
       script: 'npx semantic-release'
       skip_cleanup: true
       on:
-          branch: fix/npm-publishing
-    - provider: script
-      script: 'npx semantic-release'
-      skip_cleanup: true
-      on:
           branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_deploy:
     - git config --global user.name ${GITHUB_USER}
     - git remote set-url origin "https://${GITHUB_TOKEN}@github.com/energywebfoundation/iam-client-lib.git" > /dev/null 2>&1
     - git reset --hard
-    - echo "//registry.npmjs.org/:_authToken=\${NPM_API_TOKEN}" >> $HOME/.npmrc 2> /dev/null
+    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
     - git fetch origin master:master
     - git fetch origin develop:develop
 


### PR DESCRIPTION
According to Semantic-Release npm plugin documentation, there must be an `NPM_TOKEN` environment variable: https://github.com/semantic-release/npm

![image](https://user-images.githubusercontent.com/4407464/107280532-b34da600-6a15-11eb-8860-9fcf6c907e52.png)

Was able to successfully publish package with this change:
https://travis-ci.com/github/energywebfoundation/iam-client-lib/jobs/481366487