### PR TITLE
feat(login): store session information on iam side

### DIFF
--- a/src/cacheServerClient/cacheServerClient.ts
+++ b/src/cacheServerClient/cacheServerClient.ts
@@ -74,13 +74,13 @@ export class CacheServerClient implements ICacheServerClient {
 
   constructor({ url }: { url: string }) {
     this.httpClient = axios.create({
-      baseURL: url
+      baseURL: url,
+      withCredentials: true
     });
   }
 
   async login(identityToken: string) {
-    const { data } = await this.httpClient.post<{ token: string }>("/login", { identityToken });
-    this.httpClient.defaults.headers.common["Authorization"] = `Bearer ${data.token}`;
+    await this.httpClient.post<{ token: string }>("/login", { identityToken });
   }
 
   async getRoleDefinition({ namespace }: { namespace: string }) {

--- a/src/errors/ErrorMessages.ts
+++ b/src/errors/ErrorMessages.ts
@@ -19,5 +19,6 @@ export enum ERROR_MESSAGES {
   PUBLIC_KEY_NOT_RECOVERED = "Public key not recovered",
   ORG_WITH_APPS = "You are not able to remove organization with registered apps",
   ORG_WITH_ROLES = "You are not able to remove organization with registered roles",
-  APP_WITH_ROLES = "You are not able to remove application with registered roles"
+  APP_WITH_ROLES = "You are not able to remove application with registered roles",
+  METAMASK_EXTENSION_NOT_AVAILABLE = "Selected Metamask provider but Metamask not available"
 }

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -100,20 +100,6 @@ export class IAM extends IAMBase {
     return { isMetamaskPresent: !!provider, chainId };
   }
 
-  static isSessionActive() {
-    if (window && window.sessionStorage) {
-      return Boolean(sessionStorage.getItem(PUBLIC_KEY));
-    }
-    return false;
-  }
-
-  static getProviderType() {
-    if (window && window.sessionStorage) {
-      const providerType = sessionStorage.getItem(WALLET_PROVIDER) as WalletProvider | null;
-      return providerType;
-    }
-    return null;
-  }
   // GETTERS
 
   /**
@@ -137,6 +123,24 @@ export class IAM extends IAMBase {
   }
 
   // CONNECTION
+
+  /**
+   * Check if session is active
+   *
+   * @returns boolean that indicates the session state
+   */
+  isSessionActive() {
+    return Boolean(this._publicKey) && Boolean(this._providerType);
+  }
+
+  /**
+   * Get the current initialized provider type
+   *
+   * @returns provider type if the session is active if not undefined
+   */
+  getProviderType() {
+    return this._providerType;
+  }
 
   /**
    * Initialize connection to wallet
@@ -184,25 +188,6 @@ export class IAM extends IAMBase {
       identityToken: this._didSigner?.identityToken,
       realtimeExchangeConnected: Boolean(this._natsConnection)
     };
-  }
-
-  /**
-   * Close connection to wallet
-   * @description closes the connection between dApp and the wallet
-   *
-   */
-
-  async closeConnection() {
-    if (this._walletConnectProvider) {
-      await this._walletConnectProvider.close();
-    }
-    this.clearSession();
-    this._did = undefined;
-    this._address = undefined;
-    this._signer = undefined;
-    if (this._runningInBrowser) {
-      location.reload();
-    }
   }
 
   /**

--- a/src/signer/Signer.ts
+++ b/src/signer/Signer.ts
@@ -8,7 +8,7 @@ export class Owner extends Signer implements IdentityOwner {
     private signer: Signer,
     public provider: Provider,
     public publicKey: string,
-    public identityToken: string,
+    public identityToken?: string,
     public privateKey?: string
   ) {
     super();

--- a/src/signer/SignerFactory.ts
+++ b/src/signer/SignerFactory.ts
@@ -14,8 +14,20 @@ import { ERROR_MESSAGES } from "../errors";
 import { Owner } from "./Signer";
 
 export class SignerFactory {
-  static async create(signer: Signer, provider: Provider, privateKey?: string): Promise<Owner> {
-    const { publicKey, identityToken } = await this.getPublicKeyAndIdentityToken(signer);
+  static async create({
+    signer,
+    provider,
+    privateKey,
+    publicKey: savedPublicKey
+  }: {
+    signer: Signer;
+    provider: Provider;
+    privateKey?: string;
+    publicKey?: string;
+  }): Promise<Owner> {
+    const { publicKey, identityToken } = savedPublicKey
+      ? { publicKey: savedPublicKey, identityToken: undefined }
+      : await this.getPublicKeyAndIdentityToken(signer);
     return new Owner(signer, provider, publicKey, identityToken, privateKey);
   }
 

--- a/test/application.testSuite.ts
+++ b/test/application.testSuite.ts
@@ -1,32 +1,36 @@
 import { ENSNamespaceTypes, IAM } from "../src/iam";
-import { iam, root, rootOwner } from './iam.test';
-import { org1 } from './organization.testSuite';
+import { iam, root, rootOwner } from "./iam.test";
+import { org1 } from "./organization.testSuite";
 import { ensResolver, ensRegistry, didContract, replenish } from "./setup_contracts";
 import { namehash } from "ethers/utils";
 import { Keys } from "@ew-did-registry/keys";
 
 export const appsTests = () => {
-  const app = 'app1';
+  const app = "app1";
   const appNode = `${app}.${ENSNamespaceTypes.Application}.${org1}.${root}`;
 
-  test('application can be created', async () => {
+  test("application can be created", async () => {
     await iam.createApplication({
       appName: app,
-      data: { appName: 'Application 1' },
+      data: { appName: "Application 1" },
       namespace: `${ENSNamespaceTypes.Application}.${org1}.${root}`
     });
 
     expect(await iam.checkExistenceOfDomain({ domain: appNode })).toBe(true);
-    expect(await iam.checkExistenceOfDomain({ domain: `${ENSNamespaceTypes.Roles}.${appNode}` })).toBe(true);
+    expect(
+      await iam.checkExistenceOfDomain({ domain: `${ENSNamespaceTypes.Roles}.${appNode}` })
+    ).toBe(true);
     expect(await ensResolver.name(namehash(appNode))).toBe(appNode);
-    expect(await iam.getSubdomains({ domain: `${ENSNamespaceTypes.Application}.${org1}.${root}` })).toContain(app);
+    expect(
+      await iam.getSubdomains({ domain: `${ENSNamespaceTypes.Application}.${org1}.${root}` })
+    ).toContain(app);
   });
 
-  test('application owner can be changed', async () => {
+  test("application owner can be changed", async () => {
     const newOwner = new Keys();
     await replenish(newOwner.getAddress());
     const newOwnerIam = new IAM({
-      rpcUrl: 'http://localhost:8544/',
+      rpcUrl: "http://localhost:8544/",
       chainId: 9,
       ensRegistryAddress: ensRegistry.address,
       ensResolverAddress: ensResolver.address,
@@ -34,7 +38,8 @@ export const appsTests = () => {
       privateKey: newOwner.privateKey
     });
     await newOwnerIam.initializeConnection({
-      reinitializeMetamask: false
+      reinitializeMetamask: false,
+      walletProvider: undefined
     });
 
     expect(await iam.isOwner({ domain: appNode, user: rootOwner.getAddress() }));
@@ -54,7 +59,7 @@ export const appsTests = () => {
     expect(await iam.isOwner({ domain: appNode, user: rootOwner.getAddress() }));
   });
 
-  test('application can be deleted', async () => {
+  test("application can be deleted", async () => {
     expect(await iam.checkExistenceOfDomain({ domain: appNode })).toBe(true);
 
     await iam.deleteApplication({

--- a/test/signer/signerFactory.test.ts
+++ b/test/signer/signerFactory.test.ts
@@ -1,23 +1,24 @@
-import { providers, Wallet } from 'ethers';
-import { computePublicKey } from 'ethers/utils';
-import { SignerFactory } from '../../src/signer/SignerFactory';
-import { KmsSignerMock } from './KmsSignerMock';
+import { providers, Wallet } from "ethers";
+import { computePublicKey } from "ethers/utils";
+import { SignerFactory } from "../../src/signer/SignerFactory";
+import { KmsSignerMock } from "./KmsSignerMock";
 
 const privateKey = "0xde0aac51c154f9d467653ae882da9b77d0699b88d98f8bb4b03fd5e687b00824";
 const expectedPublicKey = computePublicKey(privateKey, true).slice(2);
 const provider = new providers.JsonRpcProvider("not-used");
 
 describe("SignerFactory", () => {
-  it('computes correct publicKey from ethers Wallet signature', async () => {
+  it("computes correct publicKey from ethers Wallet signature", async () => {
     const wallet = new Wallet(privateKey);
-    const owner = await SignerFactory.create(wallet, provider);
+    const expectedPublicKey = computePublicKey(wallet.privateKey, true).slice(2);
+    const provider = new providers.JsonRpcProvider("https://myRPC.org");
+    const owner = await SignerFactory.create({ provider, signer: wallet });
     expect(owner.publicKey).toStrictEqual(expectedPublicKey);
   });
 
-  it('computes correct publicKey from km-crypto signature', async () => {
-    const mockKmsSigner = new KmsSignerMock(privateKey); 
-    const owner = await SignerFactory.create(mockKmsSigner, provider);
+  it("computes correct publicKey from km-crypto signature", async () => {
+    const mockKmsSigner = new KmsSignerMock(privateKey);
+    const owner = await SignerFactory.create({ signer: mockKmsSigner, provider });
     expect(owner.publicKey).toStrictEqual(expectedPublicKey);
   });
 });
-


### PR DESCRIPTION
This PR contains changes required to move controle of wallet's session to iam-client-lib:
- storing information about current session(publicKey, walletProvider)
- authentication using cookie
- handling networkChange, accountChange and disconnect events
- add static methods to get info about current session

PR needs to merge after [iam-cache-server PR](https://github.com/energywebfoundation/iam-cache-server/pull/65) .