### PR TITLE
fix(exchange): multiple connections to NATS websocket

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -20,13 +20,12 @@ import {
   DIDAttribute,
   IDIDDocument,
   IServiceEndpoint,
-  IUpdateData,
-  PubKeyType
+  IUpdateData
 } from "@ew-did-registry/did-resolver-interface";
 import { hashes, IProofData, ISaltedFields } from "@ew-did-registry/claims";
 import { namehash } from "./utils/ENS_hash";
 import { v4 as uuid } from "uuid";
-import { IAMBase, emptyAddress, ClaimData, WALLET_PROVIDER, PUBLIC_KEY } from "./iam/iam-base";
+import { IAMBase, emptyAddress, ClaimData } from "./iam/iam-base";
 import {
   CacheClientNotProvidedError,
   ChangeOwnershipNotPossibleError,

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -429,7 +429,8 @@ export class IAMBase {
         const connection = await Promise.race<NatsConnection | undefined>([
           connect({
             servers: `${protocol}://${this._natsServerUrl}`,
-            timeout
+            timeout,
+            pingInterval: 50 * 1000
           }),
           new Promise<undefined>(resolve => setTimeout(resolve, timeout))
         ]);


### PR DESCRIPTION
Our nats exchange server is behind cloudflare, and cloudflare is closing websocket connection after 100 seconds of idleness.
This PR basicly changes the ping interval to 90 seconds to omit closing connection by cloudflare. 