### PR TITLE
include isOwned to org hieararchy

### DIFF
--- a/src/GnosisIam.ts
+++ b/src/GnosisIam.ts
@@ -141,7 +141,7 @@ export class GnosisIam extends IAM {
       });
   }
 
-  async getOrgHierarchy({ namespace }: { namespace: string }) {
+  async getOrgHierarchy({ namespace }: { namespace: string }): Promise<IOrganization> {
     if (!this._cacheClient) {
       throw new CacheClientNotProvidedError();
     }

--- a/src/GnosisIam.ts
+++ b/src/GnosisIam.ts
@@ -147,7 +147,7 @@ export class GnosisIam extends IAM {
     }
     const org = await this._cacheClient.getOrgHierarchy({ namespace });
     [org, ...org.subOrgs || [], ...org.apps || [], ...org.roles || []]
-      .forEach((domain) => domain.isOwned = [this._address, this.safeAddress].includes(domain.owner));
+      .forEach((domain) => domain.isOwnedByCurrentUser = [this._address, this.safeAddress].includes(domain.owner));
     return org;
   }
 }

--- a/src/GnosisIam.ts
+++ b/src/GnosisIam.ts
@@ -140,4 +140,14 @@ export class GnosisIam extends IAM {
         notOwnedNamespaces: new Array<string>()
       });
   }
+
+  async getOrgHierarchy({ namespace }: { namespace: string }) {
+    if (!this._cacheClient) {
+      throw new CacheClientNotProvidedError();
+    }
+    const org = await this._cacheClient.getOrgHierarchy({ namespace });
+    [org, ...org.subOrgs || [], ...org.apps || [], ...org.roles || []]
+      .forEach((domain) => domain.isOwned = [this._address, this.safeAddress].includes(domain.owner));
+    return org;
+  }
 }

--- a/src/cacheServerClient/cacheServerClient.types.ts
+++ b/src/cacheServerClient/cacheServerClient.types.ts
@@ -44,7 +44,7 @@ export interface IRole {
   namespace: string;
   owner: string;
   definition: IRoleDefinition;
-  isOwned?: boolean;
+  isOwnedByCurrentUser?: boolean;
 }
 
 export interface IOrganization {
@@ -56,7 +56,7 @@ export interface IOrganization {
   apps?: IApp[];
   roles?: IRole[];
   subOrgs?: IOrganization[];
-  isOwned?: boolean;
+  isOwnedByCurrentUser?: boolean;
 }
 
 export interface IApp {
@@ -66,7 +66,7 @@ export interface IApp {
   owner: string;
   definition: IAppDefinition;
   roles?: IRole[];
-  isOwned?: boolean;
+  isOwnedByCurrentUser?: boolean;
 }
 
 export interface Claim {

--- a/src/cacheServerClient/cacheServerClient.types.ts
+++ b/src/cacheServerClient/cacheServerClient.types.ts
@@ -44,7 +44,7 @@ export interface IRole {
   namespace: string;
   owner: string;
   definition: IRoleDefinition;
-  isOwned: boolean;
+  isOwned?: boolean;
 }
 
 export interface IOrganization {
@@ -66,7 +66,7 @@ export interface IApp {
   owner: string;
   definition: IAppDefinition;
   roles?: IRole[];
-  isOwned: boolean;
+  isOwned?: boolean;
 }
 
 export interface Claim {

--- a/src/cacheServerClient/cacheServerClient.types.ts
+++ b/src/cacheServerClient/cacheServerClient.types.ts
@@ -44,6 +44,7 @@ export interface IRole {
   namespace: string;
   owner: string;
   definition: IRoleDefinition;
+  isOwned: boolean;
 }
 
 export interface IOrganization {
@@ -55,6 +56,7 @@ export interface IOrganization {
   apps?: IApp[];
   roles?: IRole[];
   subOrgs?: IOrganization[];
+  isOwned?: boolean;
 }
 
 export interface IApp {
@@ -64,6 +66,7 @@ export interface IApp {
   owner: string;
   definition: IAppDefinition;
   roles?: IRole[];
+  isOwned: boolean;
 }
 
 export interface Claim {

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1091,7 +1091,7 @@ export class IAM extends IAMBase {
     }
     const org = await this._cacheClient.getOrgHierarchy({ namespace });
     [org, ...org.subOrgs || [], ...org.apps || [], ...org.roles || []]
-      .forEach((domain) => domain.isOwned = domain.owner === this.address);
+      .forEach((domain) => domain.isOwnedByCurrentUser = domain.owner === this.address);
     return org;
   }
 

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -38,6 +38,7 @@ import {
 } from "./errors";
 import {
   IAppDefinition,
+  IOrganization,
   IOrganizationDefinition,
   IRoleDefinition
 } from "./cacheServerClient/cacheServerClient.types";
@@ -1084,11 +1085,14 @@ export class IAM extends IAMBase {
    * @returns organization with all nested subOrgs
    *
    */
-  getOrgHierarchy({ namespace }: { namespace: string }) {
+  async getOrgHierarchy({ namespace }: { namespace: string }): Promise<IOrganization> {
     if (!this._cacheClient) {
       throw new CacheClientNotProvidedError();
     }
-    return this._cacheClient.getOrgHierarchy({ namespace });
+    const org = await this._cacheClient.getOrgHierarchy({ namespace });
+    [org, ...org.subOrgs || [], ...org.apps || [], ...org.roles || []]
+      .forEach((domain) => domain.isOwned = domain.owner === this.address);
+    return org;
   }
 
   /**


### PR DESCRIPTION
To enable ownership checking in extended version of Iam return type of `getOrgHieararchy` is appended with  `isOwned` property