### PR TITLE
feature/allow to operate over domains of owner

### DIFF
--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -621,11 +621,11 @@ export class IAMBase {
     return this._ensRegistry.owner(node);
   }
 
-  protected async send(tx: Transaction) {
+  protected async send({ calls }: Transaction) {
     if (!this._signer) {
       throw new Error(ERROR_MESSAGES.SIGNER_NOT_INITIALIZED);
     }
-    for await (const call of tx.calls) {
+    for await (const call of calls) {
       await (await this._signer.sendTransaction({ ...call, ...this._transactionOverrides })).wait();
     }
   }

--- a/test/approval.testSuite.ts
+++ b/test/approval.testSuite.ts
@@ -1,0 +1,51 @@
+import { Keys } from "@ew-did-registry/keys";
+import { IAM } from "../src/iam";
+import { iam, root, rootOwner, rpcUrl } from "./iam.test";
+import { org1 } from "./organization.testSuite";
+import { didContract, ensRegistry, ensResolver, replenish } from "./setup_contracts";
+
+const operatorKeys = new Keys();
+const appName = 'app1';
+
+export const approvalTests = () => {
+  let operator: IAM;
+  const namespace = `apps.${org1}.${root}`;
+
+  beforeAll(async () => {
+    operator = new IAM({
+      rpcUrl,
+      chainId: 73799,
+      ensRegistryAddress: ensRegistry.address,
+      ensResolverAddress: ensResolver.address,
+      didContractAddress: didContract.address,
+      privateKey: operatorKeys.privateKey
+    });
+    await replenish(operatorKeys.getAddress());
+
+    await operator.initializeConnection({});
+    await iam.setApproval({
+      operator: operator.address as string,
+      approve: true
+    });
+    expect(await operator.isOperatorOf(iam.address as string)).toBe(true);
+  });
+
+  test('operator can delete owner application', async () => {
+    await iam.createApplication({
+      appName,
+      namespace,
+      data: {
+        appName: 'App 1'
+      },
+      returnSteps: false
+    });
+    console.log('root owner ownes app1:', await iam.isOwner({ domain: `${appName}.${namespace}`, user: rootOwner.getAddress() }));
+    expect(await iam.checkExistenceOfDomain({ domain: `${appName}.${namespace}` })).toBe(true);
+
+    await operator.deleteApplication({
+      namespace: `${appName}.${namespace}`,
+      returnSteps: false
+    });
+    expect(await iam.checkExistenceOfDomain({ domain: `${appName}.${namespace}` })).toBe(false);
+  });
+};

--- a/test/iam.test.ts
+++ b/test/iam.test.ts
@@ -7,6 +7,7 @@ import { orgTests } from "./organization.testSuite";
 import { appsTests } from "./application.testSuite";
 import { initializeConnectionTests } from "./initializeConnection.testSuite";
 import { claimsTests } from "./claims.testSuite";
+import { approvalTests } from "./approval.testSuite";
 
 const { namehash, bigNumberify } = utils;
 
@@ -72,4 +73,5 @@ describe("IAM tests", () => {
   describe("Application tests", appsTests);
   describe("InitializeConnection tests", initializeConnectionTests);
   describe("Claim tests", claimsTests);
+  describe("Approval tests", approvalTests);
 });

--- a/test/setup_contracts.ts
+++ b/test/setup_contracts.ts
@@ -10,7 +10,7 @@ const { parseEther } = utils;
 
 const { abi: didContractAbi, bytecode: didContractBytecode } = ethrReg;
 
-const GANACHE_PORT = 8544;
+export const GANACHE_PORT = 8544;
 export const provider = new JsonRpcProvider(`http://localhost:${GANACHE_PORT}`);
 export let ensRegistry: EnsRegistry;
 export let ensResolver: PublicResolver;


### PR DESCRIPTION
Introduced notion of Operator - an actor who is allowed to operate on someone domains
- [x] added `isOperatorOf` which checks whether the signer is approved in EnsRegistry in base Iam or (in Gnosis Iam) controls safe wallet
- [x] added method to approve and check approval
- [ ] synchronize approval in `EnsRegistry` with approval in `EnsResolver`. Missing this disable updating node metadata
-    [ ] operator enabled:
     - [x] to delete owner's domain
     - [ ] to create subdomains under owner domain
     - [ ] update owner domain