### PR TITLE
Fix/myen 625 qr code when logging out

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -90,8 +90,8 @@ export class IAM extends IAMBase {
   static async isMetamaskExtensionPresent() {
     const provider = (await detectEthereumProvider({ mustBeMetaMask: true })) as
       | {
-          request: any;
-        }
+        request: any;
+      }
       | undefined;
 
     const chainId = (await provider?.request({
@@ -198,8 +198,8 @@ export class IAM extends IAMBase {
    *
    */
   isConnected(): boolean {
-    if (this._walletConnectProvider) {
-      return this._walletConnectProvider.connected;
+    if (this._providerType && [WalletProvider.EwKeyManager, WalletProvider.WalletConnect].includes(this._providerType)) {
+      return this._walletConnectService.isConnected();
     }
     return !!this._address;
   }
@@ -234,8 +234,8 @@ export class IAM extends IAMBase {
         ...document,
         service: includeClaims
           ? await this.downloadClaims({
-              services: document.service && document.service.length > 0 ? document.service : []
-            })
+            services: document.service && document.service.length > 0 ? document.service : []
+          })
           : []
       };
     }
@@ -696,8 +696,8 @@ export class IAM extends IAMBase {
     const apps = this._cacheClient
       ? await this.getAppsByOrgNamespace({ namespace })
       : await this.getSubdomains({
-          domain: `${ENSNamespaceTypes.Application}.${namespace}`
-        });
+        domain: `${ENSNamespaceTypes.Application}.${namespace}`
+      });
     if (apps && apps.length > 0) {
       throw new Error("You are not able to change ownership of organization with registered apps");
     }
@@ -820,8 +820,8 @@ export class IAM extends IAMBase {
     const apps = this._cacheClient
       ? await this.getAppsByOrgNamespace({ namespace })
       : await this.getSubdomains({
-          domain: `${ENSNamespaceTypes.Application}.${namespace}`
-        });
+        domain: `${ENSNamespaceTypes.Application}.${namespace}`
+      });
     if (apps && apps.length > 0) {
       throw new Error(ERROR_MESSAGES.ORG_WITH_APPS);
     }
@@ -1460,8 +1460,8 @@ export class IAM extends IAMBase {
         type === ENSNamespaceTypes.Roles
           ? [namespace]
           : type === ENSNamespaceTypes.Application
-          ? [namespace, ENSNamespaceTypes.Application]
-          : [namespace, ENSNamespaceTypes.Application, ENSNamespaceTypes.Organization];
+            ? [namespace, ENSNamespaceTypes.Application]
+            : [namespace, ENSNamespaceTypes.Application, ENSNamespaceTypes.Organization];
       return Promise.all(
         namespacesToCheck.map(ns => this.getOwner({ namespace: ns }))
       ).then(owners => owners.filter(o => ![owner, emptyAddress].includes(o)));

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -268,7 +268,7 @@ export class IAMBase {
           const encoded = encodeURIComponent(wcUri);
           const hasQueryString = this._ewKeyManagerUrl.includes("?");
           const url = `${this._ewKeyManagerUrl}${hasQueryString ? "&" : "?"}uri=${encoded}`;
-          window.open(url, "_blank");
+          window.open(url, "ew_key_manager");
         });
       }
 

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -1,5 +1,3 @@
-import WalletConnectProvider from "@walletconnect/web3-provider";
-import QRCodeModal from "@walletconnect/qrcode-modal";
 import { providers, Signer, utils, errors, Wallet } from "ethers";
 import { ethrReg, Operator, Resolver } from "@ew-did-registry/did-ethr-resolver";
 import { labelhash, namehash } from "../utils/ENS_hash";
@@ -30,13 +28,13 @@ import { WalletProvider } from "../types/WalletProvider";
 import { SignerFactory } from "../signer/SignerFactory";
 import { CacheServerClient } from "../cacheServerClient/cacheServerClient";
 import { emptyAddress, MessagingMethod, PUBLIC_KEY, WALLET_PROVIDER } from "../utils/constants";
-import { ControllableWalletConnect } from "../walletconnect/ControllableWalletConnect";
 import {
   cacheServerClientOptions,
   chainConfigs,
   messagingOptions,
   MessagingOptions
 } from "./chainConfig";
+import { WalletConnectService } from "../walletconnect/WalletConnectService";
 
 const { hexlify, bigNumberify } = utils;
 const { JsonRpcProvider } = providers;
@@ -79,9 +77,8 @@ export class IAMBase {
 
   protected _did: string | undefined;
   protected _provider: providers.JsonRpcProvider;
-  protected _walletConnectProvider: WalletConnectProvider | undefined;
-  protected _walletConnectClient: ControllableWalletConnect | undefined;
   protected _metamaskProvider: { on: any; request: any } | undefined;
+  protected _walletConnectService: WalletConnectService
   protected _address: string | undefined;
   protected _signer: Signer | undefined;
   protected _safeAddress: string | undefined;
@@ -110,7 +107,6 @@ export class IAMBase {
   protected _natsConnection: NatsConnection | undefined;
   protected _jsonCodec: Codec<any> | undefined;
 
-  private readonly _ewKeyManagerUrl: string;
   private ttl = bigNumberify(0);
 
   /**
@@ -145,7 +141,7 @@ export class IAMBase {
       }
     }
 
-    this._ewKeyManagerUrl = ewKeyManagerUrl;
+    this._walletConnectService = new WalletConnectService(bridgeUrl, infuraId, ewKeyManagerUrl);
   }
 
   // INITIAL
@@ -191,7 +187,7 @@ export class IAMBase {
     initializeMetamask?: boolean;
     walletProvider?: WalletProvider;
   }) {
-    const { privateKey, rpcUrl, bridgeUrl, infuraId } = this._connectionOptions;
+    const { privateKey, rpcUrl } = this._connectionOptions;
 
     if (!this._runningInBrowser) {
       if (!privateKey) {
@@ -248,40 +244,9 @@ export class IAMBase {
         gasLimit: hexlify(4900000),
         gasPrice: hexlify(0.1)
       };
-
-      const showQRCode = !(walletProvider === WalletProvider.EwKeyManager);
-
-      const rpc = Object.entries(chainConfigs).reduce(
-        (urls, [id, config]) => ({ ...urls, [id]: config.rpcUrl }),
-        {}
-      );
-
-      this._walletConnectClient = new ControllableWalletConnect({
-        bridge: bridgeUrl,
-        qrcodeModal: showQRCode ? QRCodeModal : undefined
-      });
-
-      this._walletConnectProvider = new WalletConnectProvider({
-        rpc,
-        infuraId,
-        connector: this._walletConnectClient
-      });
-
-      if (walletProvider === WalletProvider.EwKeyManager) {
-        this._walletConnectProvider.wc.on("display_uri", (err, payload) => {
-          // uri is expected to be WalletConnect Standard URI https://eips.ethereum.org/EIPS/eip-1328
-          const wcUri = payload.params[0];
-
-          const encoded = encodeURIComponent(wcUri);
-          const hasQueryString = this._ewKeyManagerUrl.includes("?");
-          const url = `${this._ewKeyManagerUrl}${hasQueryString ? "&" : "?"}uri=${encoded}`;
-          window.open(url, "ew_key_manager");
-        });
-      }
-
-      await this._walletConnectProvider.enable();
-
-      this._signer = new providers.Web3Provider(this._walletConnectProvider).getSigner();
+      await this._walletConnectService.initialize(walletProvider);
+      const wcProvider = this._walletConnectService.getProvider();
+      this._signer = new providers.Web3Provider(wcProvider).getSigner();
       this._provider = this._signer.provider as providers.Web3Provider;
       this._providerType = walletProvider;
       return;
@@ -306,23 +271,26 @@ export class IAMBase {
   /**
    * Add event handler for certain events
    * @requires to be called after the connection to wallet was initialized
-   *
    */
   on(event: "accountChanged" | "networkChanged" | "disconnected", eventHandler: () => void) {
     if (!this._providerType) return;
+    const isMetamask = this._providerType === WalletProvider.MetaMask;
     switch (event) {
       case "accountChanged": {
-        this._walletConnectProvider?.wc.on("session_update", eventHandler);
-        this._metamaskProvider?.on("accountsChanged", eventHandler);
+        isMetamask ?
+          this._metamaskProvider?.on("accountsChanged", eventHandler) :
+          this._walletConnectService.getProvider().wc.on("session_update", eventHandler);
         break;
       }
       case "disconnected": {
-        this._walletConnectProvider?.wc.on("disconnect", eventHandler);
+        isMetamask === false &&
+          this._walletConnectService.getProvider()?.wc.on("disconnect", eventHandler);
         break;
       }
       case "networkChanged": {
-        this._walletConnectProvider?.wc.on("session_update", eventHandler);
-        this._metamaskProvider?.on("networkChanged", eventHandler);
+        isMetamask ?
+          this._metamaskProvider?.on("networkChanged", eventHandler) :
+          this._walletConnectService.getProvider().wc.on("session_update", eventHandler);
         break;
       }
       default:
@@ -348,12 +316,7 @@ export class IAMBase {
    *
    */
   async closeConnection() {
-    if (this._walletConnectProvider) {
-      if (this._walletConnectClient) {
-        this._walletConnectClient.canCreateSession = false;
-      }
-      await this._walletConnectProvider.close();
-    }
+    await this._walletConnectService.closeConnection();
     this.clearSession();
     this._did = undefined;
     this._address = undefined;

--- a/src/walletconnect/ControllableWalletConnect.ts
+++ b/src/walletconnect/ControllableWalletConnect.ts
@@ -1,0 +1,21 @@
+import WalletConnect from "@walletconnect/client";
+import { IWalletConnectOptions, ICreateSessionOptions } from "@walletconnect/types";
+
+/**
+ * Extension of WalletConnect client that allows session creation to be disabled
+ * This is helpful to be sure that session creation won't be attempted after closing 
+ * the connection. See [MYEN-625](https://energyweb.atlassian.net/browse/MYEN-625)
+ */
+export class ControllableWalletConnect extends WalletConnect {
+  public canCreateSession = true;
+
+  constructor(connectorOpts: IWalletConnectOptions) {
+    super(connectorOpts);
+  }
+
+  public async createSession(opts?: ICreateSessionOptions): Promise<void> {
+    if (this.canCreateSession) {
+      super.createSession(opts);
+    }
+  }
+}

--- a/src/walletconnect/WalletConnectService.ts
+++ b/src/walletconnect/WalletConnectService.ts
@@ -1,0 +1,86 @@
+import WalletConnectProvider from "@walletconnect/web3-provider";
+import QRCodeModal from "@walletconnect/qrcode-modal";
+import { ControllableWalletConnect } from "./ControllableWalletConnect";
+import { WalletProvider } from "../types/WalletProvider";
+import { chainConfigs } from "../iam/chainConfig";
+
+/**
+ * Encapsulates a WalletConnect connection
+ */
+export class WalletConnectService {
+  private readonly _ewKeyManagerUrl: string | undefined;
+  private readonly _infuraId: string | undefined;
+  private readonly _bridgeUrl: string;
+  protected _walletConnectProvider: WalletConnectProvider | undefined;
+  protected _walletConnectClient: ControllableWalletConnect | undefined;
+
+  constructor(bridgeUrl: string, infuraId?: string, ewKeyManagerUrl?: string) {
+    this._ewKeyManagerUrl = ewKeyManagerUrl;
+    this._bridgeUrl = bridgeUrl;
+    this._infuraId = infuraId;
+  }
+
+  async initialize(walletProvider: WalletProvider) {
+    const showQRCode = !(walletProvider === WalletProvider.EwKeyManager);
+
+    this._walletConnectClient = new ControllableWalletConnect({
+      bridge: this._bridgeUrl,
+      qrcodeModal: showQRCode ? QRCodeModal : undefined
+    });
+
+    const rpc = Object.entries(chainConfigs).reduce(
+      (urls, [id, config]) => ({ ...urls, [id]: config.rpcUrl }),
+      {}
+    );
+
+    this._walletConnectProvider = new WalletConnectProvider({
+      rpc,
+      infuraId: this._infuraId,
+      connector: this._walletConnectClient
+    });
+
+    if (walletProvider === WalletProvider.EwKeyManager) {
+      if (!this._ewKeyManagerUrl) {
+        throw Error("EwKeyManager provider type specified but no url was provided.");
+      }
+      const ewKeyManagerUrl = this._ewKeyManagerUrl;
+      this._walletConnectProvider.wc.on("display_uri", (err, payload) => {
+        // uri is expected to be WalletConnect Standard URI https://eips.ethereum.org/EIPS/eip-1328
+        const wcUri = payload.params[0];
+
+        const encoded = encodeURIComponent(wcUri);
+        const hasQueryString = ewKeyManagerUrl.includes("?");
+        const url = `${this._ewKeyManagerUrl}${hasQueryString ? "&" : "?"}uri=${encoded}`;
+        window.open(url, "ew_key_manager");
+      });
+    }
+
+    await this._walletConnectProvider.enable();
+  }
+
+  /**
+   * @requires intialize be called first
+   * @returns the WalletConnectProvider of this instance
+   */
+  getProvider(): WalletConnectProvider {
+    if (!this._walletConnectProvider) {
+      throw Error("call initalize() to initialize provider first");
+    }
+    return this._walletConnectProvider;
+  }
+
+  async closeConnection(): Promise<void> {
+    if (this._walletConnectClient) {
+      // Setting to false to that WalletConnect library doesn't 
+      // try to recreate session after closing
+      this._walletConnectClient.canCreateSession = false;
+    }
+    if (this._walletConnectProvider) {
+      await this._walletConnectProvider.close();
+    }
+  }
+
+  isConnected(): boolean {
+    return this._walletConnectProvider?.connected ?? false;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": false,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "es5"
+    "target": "es2017"
   },
   "include": ["src/**/*", "ethers/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": false,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "es2017"
+    "target": "es6"
   },
   "include": ["src/**/*", "ethers/**/*"]
 }


### PR DESCRIPTION
Note the 3 commits, maybe easier to look at them separately.
fix: add window name back for KM login -> This is small one-liner, putting back change that was there before.
fix: add ControllableWalletConnect MYEN-625 -> This is workaround to fix MYEN-625
refactor: encapsulated WalletConnect functionality -> I feel like `iam-base` is rather long so thought it would be good to pull out and encapsulate the WalletConnect stuff
