### PR TITLE
fix: add stopwatch logging of iam init

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -154,8 +154,9 @@ export class IAM extends IAMBase {
    */
   async initializeConnection({
     walletProvider = this._providerType,
-    reinitializeMetamask
-  }: { walletProvider?: WalletProvider; reinitializeMetamask?: boolean } = {}): Promise<
+    reinitializeMetamask,
+    logStopwatch = false
+  }: { walletProvider?: WalletProvider; reinitializeMetamask?: boolean, logStopwatch?: boolean } = {}): Promise<
     InitializeData
   > {
     const { privateKey } = this._connectionOptions;
@@ -169,7 +170,8 @@ export class IAM extends IAMBase {
     try {
       await this.init({
         initializeMetamask: reinitializeMetamask,
-        walletProvider
+        walletProvider,
+        logStopwatch
       });
     } catch (err) {
       if (err.message === "User closed modal") {

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -155,7 +155,7 @@ export class IAM extends IAMBase {
   async initializeConnection({
     walletProvider = this._providerType,
     reinitializeMetamask,
-    logStopwatch = false
+    logStopwatch
   }: { walletProvider?: WalletProvider; reinitializeMetamask?: boolean, logStopwatch?: boolean } = {}): Promise<
     InitializeData
   > {

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -151,7 +151,7 @@ export class IAMBase {
   protected async init({
     initializeMetamask,
     walletProvider: walletProvider,
-    logStopwatch = false
+    logStopwatch = true
   }: {
     initializeMetamask?: boolean;
     walletProvider?: WalletProvider;

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -143,39 +143,61 @@ export class IAMBase {
     this._walletConnectService = new WalletConnectService(bridgeUrl, infuraId, ewKeyManagerUrl);
   }
 
+  private startTime: number;
+  private elapsedTime = () => new Date().getTime() - this.startTime;
+
   // INITIAL
 
   protected async init({
     initializeMetamask,
-    walletProvider: walletProvider
+    walletProvider: walletProvider,
+    logStopwatch = false
   }: {
     initializeMetamask?: boolean;
     walletProvider?: WalletProvider;
+    logStopwatch?: boolean;
   }) {
+    this.startTime = new Date().getTime();
+    logStopwatch && console.info(this.elapsedTime(), "starting iam init");
     await this.initSigner({ walletProvider, initializeMetamask });
+    logStopwatch && console.info(this.elapsedTime(), "finished initSigner");
     await this.initChain();
+    logStopwatch && console.info(this.elapsedTime(), "finished initChain");
     this.initEventHandlers();
+    logStopwatch && console.info(this.elapsedTime(), "finished initEventHandlers");
 
     if (this._runningInBrowser) {
       await this.setupMessaging();
+      logStopwatch && console.info(this.elapsedTime(), "finished setupMessagin");
     }
     if (this._signer) {
+      logStopwatch && console.info(this.elapsedTime(), "starting SignerFactory.create");
       this._didSigner = await SignerFactory.create({
         provider: this._provider,
         signer: this._signer,
         publicKey: this._publicKey
       });
+      logStopwatch && console.info(this.elapsedTime(), "finished SignerFactory.create");
       this._publicKey = this._didSigner.publicKey;
       this._didSigner.identityToken &&
         (await this.loginToCacheServer(this._didSigner.identityToken));
+      logStopwatch && console.info(this.elapsedTime(), "finished loginToCacheServer");
       await this.setAddress();
+      logStopwatch && console.info(this.elapsedTime(), "finished setAddress");
       this.setDid();
+      logStopwatch && console.info(this.elapsedTime(), "finished setDid");
       await this.setDocument();
+      logStopwatch && console.info(this.elapsedTime(), "finished setDocument");
       this.setClaims();
+      logStopwatch && console.info(this.elapsedTime(), "finished setClaims");
     }
     this.setResolver();
+    logStopwatch && console.info(this.elapsedTime(), "finished setResolver");
     this.setJWT();
+    logStopwatch && console.info(this.elapsedTime(), "finished setJWT");
     this.storeSession();
+    logStopwatch && console.info(this.elapsedTime(), "finished storeSession");
+    logStopwatch && console.info(this.elapsedTime(), "finished iam init");
   }
 
   private async initSigner({


### PR DESCRIPTION
Would be curious to see what the results are of you running this branch with Switchboard @manihagh . Are you able to run Switchboard locally to test (if we have 15 minutes or so, I could help you with that)? Or maybe we can get it into Switchboard dev environment and then you can test there?

I'm seeing output which points to `setDocument` being the culprit. However, this doesn't completely make sense because metamask also needs to do the same thing...
```
  private async setDocument() {
    if (this._did && this._didSigner) {
      const document = new DIDDocumentFull(
        this._did,
        new Operator(this._didSigner, this._registrySetting)
      );
      await document.create();
      this._document = document;
    }
  }
```

![image](https://user-images.githubusercontent.com/4407464/112703657-5854fe80-8e5d-11eb-9d9c-aa36355f535c.png)
