### PR TITLE
feature/asset enrollment

### DIFF
--- a/src/errors/ErrorMessages.ts
+++ b/src/errors/ErrorMessages.ts
@@ -23,5 +23,6 @@ export enum ERROR_MESSAGES {
   APP_WITH_ROLES = "You are not able to remove application with registered roles",
   METAMASK_EXTENSION_NOT_AVAILABLE = "Selected Metamask provider but Metamask not available",
   ROLE_PRECONDITION_NOT_MET = "Precondition not met, user not eligible to enrol for a role",
-  ROLE_NOT_EXISTS = "Role you want to enroll to does not exists"
+  ROLE_NOT_EXISTS = "Role you want to enroll to does not exists",
+  CLAIM_PUBLISHER_NOT_REQUESTER = "Claim publisher did not requested this claim"
 }

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1284,12 +1284,14 @@ export class IAM extends IAMBase {
 
   async createClaimRequest({
     issuer,
-    claim
+    claim,
+    did = this._did
   }: {
     issuer: string[];
     claim: { claimType: string; fields: { key: string; value: string | number }[] };
+    did?: string;
   }) {
-    if (!this._did) {
+    if (!did) {
       throw new Error(ERROR_MESSAGES.USER_NOT_LOGGED_IN);
     }
 
@@ -1298,7 +1300,7 @@ export class IAM extends IAMBase {
         type: ENSNamespaceTypes.Roles,
         namespace: claim.claimType
       }),
-      this.getDidDocument({ includeClaims: true })
+      this.getDidDocument({ did, includeClaims: true })
     ]);
 
     if (!roleDefinition) {
@@ -1314,12 +1316,12 @@ export class IAM extends IAMBase {
       id: uuid(),
       token,
       claimIssuer: issuer,
-      requester: this._did || ""
+      requester: did
     };
 
     if (!this._natsConnection) {
       if (this._cacheClient) {
-        return this._cacheClient.requestClaim({ did: this._did, message });
+        return this._cacheClient.requestClaim({ did, message });
       }
       throw new NATSConnectionNotEstablishedError();
     }


### PR DESCRIPTION
- [x] To request asset enrollment signature of `IAM.createClaimRequest` will accept optional `did` parameter by default set to owner `did`. Enrollment preconditions are verified on asset
- [x] Now we need differentiate between claim requester (asset owner) and claim subject (asset). Claims produced by did-lib includes `subject` field defined in `JWT` specification but now this field used not on purpose, but to represent claim type: https://github.com/energywebfoundation/iam-client-lib/blob/eaeb20872eb6624d0c6d8c9789b4a6bb064f3ca4/src/iam.ts#L1312. This PR fixes this flaw. Claim type still can be retrived from token data 
- [x] Claim issuer will verify that claim subject is claim requester or owned by requester
- [x] After approving of enrollment request asset owner adds issued claim to asset document