### PR TITLE
bug/latest version behind canary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ deploy:
       on:
           branch: develop
     - provider: script
-      script: 'npx semantic-release'
+      script: 'npx semantic-release && git checkout develop && git merge origin/master && git push origin develop'
       skip_cleanup: true
       on:
           branch: master


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44746858/115705102-ca453880-a374-11eb-8302-d54144d2dcd5.png)

From examples in `semantic-release` repository I assume that work on new release in pre-release branch (https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#pre-release-branches) starts when branching from release branch (https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#release-branches), or when release merged into pre-release. In this repository `develop` is pre-release branch and `master` is release. As last master merged into `develop` was 2.1.0 develop continue publishing pre-releases of 2.2.
Proposed changes will "reinitialize" `develop` to publish pre-releases of next release when previous release is published