### PR TITLE
fix(deleteClaim): throw CacheClientNotProvided if necessary

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1415,8 +1415,9 @@ export class IAM extends IAMBase {
   async deleteClaim({ id }: { id: string }) {
     if (this._cacheClient) {
       await this._cacheClient.deleteClaim({ claimId: id });
+    } else {
+      throw new CacheClientNotProvidedError();
     }
-    throw new CacheClientNotProvidedError();
   }
 
   async subscribeTo({


### PR DESCRIPTION
Even if the `deleteClaim` was successful, it was still continuing to throw the error, so just added else block.