### PR TITLE
Add asset profiles types for claim data.

### DIFF
--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -70,8 +70,24 @@ export type Transaction = {
   from: string;
 };
 
+export interface AssetProfile {
+  name?: string;
+  icon?: string;
+}
+
+export interface AssetProfiles {
+  [key:string]: AssetProfile;
+}
+
+export interface Profile {
+  name?: string;
+  birthdate?: string;
+  address?: string;
+  assetProfiles?: AssetProfiles;
+}
+
 export interface ClaimData extends Record<string, unknown> {
-  profile?: any;
+  profile?: Profile;
   claimType?: string;
   claimTypeVersion?: string;
 }

--- a/test/claims.testSuite.ts
+++ b/test/claims.testSuite.ts
@@ -68,7 +68,7 @@ export const claimsTests = () => {
     await iam.createSelfSignedClaim({ data: { profile: { name: "Dan" } } });
     const { service: updatedService = [] } = await iam.getDidDocument();
     const { profile } = updatedService.find(({ id: claimId }) => id === claimId) || {};
-    expect(profile.name).toBe("Dan");
+    expect(profile?.name).toBe("Dan");
     expect(updatedService.length).toBe(4);
   });
 };


### PR DESCRIPTION
Adds types for profiles in data claim, because previously it was any.