### PR TITLE
fix: exporting interfaces for claim data.

### DIFF
--- a/src/cacheServerClient/cacheServerClient.types.ts
+++ b/src/cacheServerClient/cacheServerClient.types.ts
@@ -105,6 +105,28 @@ export interface AssetHistory {
   assetId?: string;
 }
 
+export interface AssetProfile {
+  name?: string;
+  icon?: string;
+}
+
+export interface AssetProfiles {
+  [key:string]: AssetProfile;
+}
+
+export interface Profile {
+  name?: string;
+  birthdate?: string;
+  address?: string;
+  assetProfiles?: AssetProfiles;
+}
+
+export interface ClaimData extends Record<string, unknown> {
+  profile?: Profile;
+  claimType?: string;
+  claimTypeVersion?: string;
+}
+
 export enum Order {
   "ASC" = "ASC",
   "DESC" = "DESC"

--- a/src/iam-client-lib.ts
+++ b/src/iam-client-lib.ts
@@ -34,7 +34,11 @@ import {
   Asset,
   AssetHistory,
   AssetHistoryEventType,
-  Order
+  Order,
+  ClaimData,
+  Profile,
+  AssetProfiles,
+  AssetProfile
 } from "./cacheServerClient/cacheServerClient.types";
 
 import {
@@ -84,7 +88,11 @@ export {
   IRole,
   IRoleDefinition,
   Asset,
-  AssetHistory
+  AssetHistory,
+  ClaimData,
+  Profile,
+  AssetProfiles,
+  AssetProfile
 };
 
 export { GnosisIam as SafeIam } from "./GnosisIam";

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -26,7 +26,7 @@ import { hashes, IProofData, ISaltedFields } from "@ew-did-registry/claims";
 import { ProxyOperator } from "@ew-did-registry/proxyidentity";
 import { namehash } from "./utils/ENS_hash";
 import { v4 as uuid } from "uuid";
-import { IAMBase, ClaimData } from "./iam/iam-base";
+import { IAMBase} from "./iam/iam-base";
 import {
   CacheClientNotProvidedError,
   ChangeOwnershipNotPossibleError,
@@ -38,7 +38,7 @@ import {
   ERROR_MESSAGES
 } from "./errors";
 import {
-  AssetHistoryEventType,
+  AssetHistoryEventType, ClaimData,
   IAppDefinition,
   IOrganization,
   IOrganizationDefinition,

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -16,6 +16,7 @@ import { isBrowser } from "../utils/isBrowser";
 import { connect, NatsConnection, JSONCodec, Codec } from "nats.ws";
 import { ERROR_MESSAGES } from "../errors";
 import {
+  ClaimData,
   IAppDefinition,
   IOrganizationDefinition,
   IRoleDefinition
@@ -69,28 +70,6 @@ export type Transaction = {
   calls: EncodedCall[];
   from: string;
 };
-
-export interface AssetProfile {
-  name?: string;
-  icon?: string;
-}
-
-export interface AssetProfiles {
-  [key:string]: AssetProfile;
-}
-
-export interface Profile {
-  name?: string;
-  birthdate?: string;
-  address?: string;
-  assetProfiles?: AssetProfiles;
-}
-
-export interface ClaimData extends Record<string, unknown> {
-  profile?: Profile;
-  claimType?: string;
-  claimTypeVersion?: string;
-}
 
 /**
  * @class
@@ -194,7 +173,7 @@ export class IAMBase {
       identityToken = fromCacheLogin?.identityToken;
 
       // We need a pubKey to create DID document.
-      // So if didn't get one from cache server login, need to get in some other way.  
+      // So if didn't get one from cache server login, need to get in some other way.
       if (!publicKey && this._runningInBrowser) {
         // Check local storage.
         // This is to that publicKey can be reused when refreshing the page


### PR DESCRIPTION
Problem is that those interfaces wasn't exported from library. When using nested import in switchboard there was error while building application. This PR should fix it and frontend should be able to use interfaces for ClaimData.