### PR TITLE
Swtch 941/logout forbidden

### DIFF
--- a/src/cacheServerClient/ICacheServerClient.ts
+++ b/src/cacheServerClient/ICacheServerClient.ts
@@ -17,7 +17,8 @@ import {
 
 export interface ICacheServerClient {
   pubKeyAndIdentityToken: IPubKeyAndIdentityToken | undefined;
-  login: () => Promise<void>;
+  testLogin: () => Promise<void>;
+  login: () => Promise<{ pubKeyAndIdentityToken: IPubKeyAndIdentityToken, token: string, refreshToken: string }>;
   isAuthEnabled: () => boolean;
   getRoleDefinition: ({ namespace }: { namespace: string }) => Promise<IRoleDefinition>;
   getOrgDefinition: ({ namespace }: { namespace: string }) => Promise<IOrganizationDefinition>;

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -26,7 +26,7 @@ import { hashes, IProofData, ISaltedFields } from "@ew-did-registry/claims";
 import { ProxyOperator } from "@ew-did-registry/proxyidentity";
 import { namehash } from "./utils/ENS_hash";
 import { v4 as uuid } from "uuid";
-import { IAMBase} from "./iam/iam-base";
+import { IAMBase } from "./iam/iam-base";
 import {
   CacheClientNotProvidedError,
   ChangeOwnershipNotPossibleError,
@@ -129,17 +129,6 @@ export class IAM extends IAMBase {
 
   getSigner(): providers.JsonRpcSigner | Signer | undefined {
     return this._signer;
-  }
-
-  // CONNECTION
-
-  /**
-   * Check if session is active
-   *
-   * @returns boolean that indicates the session state
-   */
-  isSessionActive() {
-    return Boolean(this._publicKey) && Boolean(this._providerType);
   }
 
   /**

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -376,7 +376,9 @@ export class IAMBase {
   }
 
   private setDid() {
-    this._did = `did:${Methods.Erc1056}:${this._address}`;
+    if (this._address) {
+      this._did = `did:${Methods.Erc1056}:${this._address}`;
+    }
   }
 
   private async setDocument() {

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -167,7 +167,7 @@ export class IAMBase {
     }
     if (this._signer) {
       const fromCacheLogin = await this.loginToCacheServer();
-      this._publicKey = this._publicKey ?? fromCacheLogin?.publicKey;
+      this._publicKey = fromCacheLogin?.publicKey ?? this._publicKey;
       this._identityToken = fromCacheLogin?.identityToken;
 
       // We need a pubKey to create DID document.


### PR DESCRIPTION
Fixing a bunch of issues with the login flow:

- fix: login as different account issue
  When logout then back in as a separate account was using old cookies.
  So check that if publicKey is there so that if not, redo login to cache-server
- fix: maintain login on reload
  sessionIsActive() should work even if init() hasn't been called
  so moved pubKey retrieval back to constructor
- fix: no sense setting DID if address hasn't been set
  So checking this._address when setDid()
- refactor: use isSessionActive() in loginToCacheServer()
  Better to have one canonical way to check if session is active