### PR TITLE
fix(iam): parse claimData from requested token

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1483,7 +1483,7 @@ export class IAM extends IAMBase {
     if (!this._jwt) {
       throw new Error(ERROR_MESSAGES.JWT_NOT_INITIALIZED);
     }
-    const { claimData, claimTypeVersion, sub } = this._jwt.decode(token) as { claimData: { claimType: string; claimTypeVersion: string }; sub: string };
+    const { claimData, sub } = this._jwt.decode(token) as { claimData: { claimType: string; claimTypeVersion: string }; sub: string };
     const issuedToken = await this.issuePublicClaim({
       token: await this._jwt.sign({ claimData }, { subject: sub, issuer: this._did })
     });

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1483,9 +1483,9 @@ export class IAM extends IAMBase {
     if (!this._jwt) {
       throw new Error(ERROR_MESSAGES.JWT_NOT_INITIALIZED);
     }
-    const { claimType, claimTypeVersion, sub } = this._jwt.decode(token) as { claimType: string; claimTypeVersion: string; sub: string };
+    const { claimData, claimTypeVersion, sub } = this._jwt.decode(token) as { claimData: { claimType: string }, claimTypeVersion: string; sub: string };
     const issuedToken = await this.issuePublicClaim({
-      token: await this._jwt.sign({ claimType, claimTypeVersion }, { subject: sub, issuer: this._did })
+      token: await this._jwt.sign({ claimData, claimTypeVersion }, { subject: sub, issuer: this._did })
     });
     const message: IClaimIssuance = {
       id,

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1483,9 +1483,9 @@ export class IAM extends IAMBase {
     if (!this._jwt) {
       throw new Error(ERROR_MESSAGES.JWT_NOT_INITIALIZED);
     }
-    const { claimData, claimTypeVersion, sub } = this._jwt.decode(token) as { claimData: { claimType: string }, claimTypeVersion: string; sub: string };
+    const { claimData, claimTypeVersion, sub } = this._jwt.decode(token) as { claimData: { claimType: string; claimTypeVersion: string }; sub: string };
     const issuedToken = await this.issuePublicClaim({
-      token: await this._jwt.sign({ claimData, claimTypeVersion }, { subject: sub, issuer: this._did })
+      token: await this._jwt.sign({ claimData }, { subject: sub, issuer: this._did })
     });
     const message: IClaimIssuance = {
       id,


### PR DESCRIPTION
- [x] potential fix
- [ ] add test -> tried to add test but too hard to mock cache-client

Current code fails eventually in `iam` `private async getClaimId({ claimData }: { claimData: ClaimData }) { ` because `claimData` is null

https://energyweb.atlassian.net/browse/SWTCH-998