### PR TITLE
feature/SWTCH-909 issue on-chain role

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1108,9 +1108,9 @@
       }
     },
     "@energyweb/iam-contracts": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/iam-contracts/-/iam-contracts-1.11.0.tgz",
-      "integrity": "sha512-EinoPzFmiWkMcl+1wF06kNL0QwNEm8ZgBaVgaBahetWFE+TXWkXP9R1tw386wO8zX2bAcz/D7KB7miM4lTiDpQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@energyweb/iam-contracts/-/iam-contracts-1.11.2.tgz",
+      "integrity": "sha512-T/tAwW7I4HP4eq+YIAwvt55qd474iapn+BnYHgd5g1AoVB38nLIVE2ld8oexikGrb1rdbgSkjcaqrBh1rFAmJA==",
       "requires": {
         "@openzeppelin/contracts": "3.4.1",
         "ethers": "4.0.45"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@energyweb/iam-contracts": "1.11.0",
+    "@energyweb/iam-contracts": "1.11.2",
     "@ensdomains/ens": "^0.4.5",
     "@ew-did-registry/claims": "0.5.2-alpha.1045.0",
     "@ew-did-registry/did": "0.5.2-alpha.1045.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:typechain:offerableIdentity": "typechain --target ethers-v4 --outDir ethers './node_modules/@ew-did-registry/proxyidentity/build/contracts/OfferableIdentity.json'",
     "build:typechain:identityManager": "typechain --target ethers-v4 --outDir ethers './node_modules/@ew-did-registry/proxyidentity/build/contracts/IdentityManager.json'",
     "prepare": "npm run build",
-    "start-rpc": "run-with-testrpc -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=9 --gasLimit=10000000",
+    "start-rpc": "run-with-testrpc -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=1 --gasLimit=10000000",
     "test:watch": "npm run start-rpc -- \"jest --coverage --env=./test/env.js --watchAll\"",
     "test:prod": "npm run start-rpc -- \"jest --no-cache --env=./test/env.js\"",
     "ganache": "ganache-cli -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=9 --gasLimit=10000000",

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -88,7 +88,9 @@ export interface IClaimRequest extends IMessage {
 }
 
 export interface IClaimIssuance extends IMessage {
+  // issuedToken is is only provided in the case of off-chain role
   issuedToken?: string;
+  // onChainProof is only provided in case of on-chain role
   onChainProof?: string;
   acceptedBy: string;
 }

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1417,7 +1417,7 @@ export class IAM extends IAMBase {
     ));
   }
 
-  async createOnChainProof(role: string, version: number, expiry: number, subject: string): Promise<string> {
+  private async createOnChainProof(role: string, version: number, expiry: number, subject: string): Promise<string> {
     if (!this._did) {
       throw new Error(ERROR_MESSAGES.USER_NOT_LOGGED_IN);
     }

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1407,7 +1407,7 @@ export class IAM extends IAMBase {
         domainSeparator,
         keccak256(defaultAbiCoder.encode(
           ["bytes32", "address", "bytes32", "uint256"],
-          [agreement_type_hash, subject, namehash(role), version]
+          [agreement_type_hash, addressOf(subject), namehash(role), version]
         ))
       ]
     );
@@ -1446,7 +1446,7 @@ export class IAM extends IAMBase {
         domainSeparator,
         utils.keccak256(defaultAbiCoder.encode(
           ["bytes32", "address", "bytes32", "uint", "uint", "address"],
-          [proof_type_hash, subject, utils.namehash(role), version, expiry, this._address]
+          [proof_type_hash, addressOf(subject), utils.namehash(role), version, expiry, this._address]
         ))
       ]
     );

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -55,7 +55,7 @@ import {
 } from "./cacheServerClient/cacheServerClient.types";
 import detectEthereumProvider from "@metamask/detect-provider";
 import { WalletProvider } from "./types/WalletProvider";
-import { emptyAddress, erc712_type_hash, NATS_EXCHANGE_TOPIC, proof_type_hash, typedMsgPrefix } from "./utils/constants";
+import { defaultClaimExpiry, emptyAddress, erc712_type_hash, NATS_EXCHANGE_TOPIC, proof_type_hash, typedMsgPrefix } from "./utils/constants";
 import { Subscription } from "nats.ws";
 import { AxiosError } from "axios";
 import { DIDDocumentFull } from "@ew-did-registry/did-document";
@@ -1545,7 +1545,8 @@ export class IAM extends IAMBase {
       });
     }
     if (registrationTypes.includes(RegistrationTypes.OnChain)) {
-      const { claimType: role, claimTypeVersion: version, expiry } = claimData;
+      const { claimType: role, claimTypeVersion: version} = claimData;
+      const expiry = claimData.expiry === undefined ? defaultClaimExpiry : claimData.expiry;
       const claimManager = ClaimManager__factory.connect(this._claimManager, this._signer);
       const onChainProof = await this.createOnChainProof(role, version, expiry, sub);
       await claimManager.register(

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1551,7 +1551,7 @@ export class IAM extends IAMBase {
       await claimManager.register(
         addressOf(sub),
         namehash(role),
-        version, 
+        version,
         expiry,
         addressOf(this._did),
         subjectAgreement,
@@ -1560,15 +1560,14 @@ export class IAM extends IAMBase {
       message.onChainProof = onChainProof;
     }
 
-    if (!this._natsConnection) {
-      if (this._cacheClient) {
-        return this._cacheClient.issueClaim({ did: this._did, message });
-      }
+    if (this._natsConnection) {
+      const dataToSend = this._jsonCodec?.encode(message);
+      this._natsConnection.publish(`${requester}.${NATS_EXCHANGE_TOPIC}`, dataToSend);
+    } else if (this._cacheClient) {
+      return this._cacheClient.issueClaim({ did: this._did, message });
+    } else {
       throw new NATSConnectionNotEstablishedError();
     }
-
-    const dataToSend = this._jsonCodec?.encode(message);
-    this._natsConnection.publish(`${requester}.${NATS_EXCHANGE_TOPIC}`, dataToSend);
   }
 
   async rejectClaimRequest({ id, requesterDID }: { id: string; requesterDID: string }) {

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -78,7 +78,7 @@ export type InitializeData = {
 export interface IMessage {
   id: string;
   requester: string;
-  claimIssuer: string[];
+  claimIssuer?: string[];
 }
 
 export interface IClaimRequest extends IMessage {
@@ -1468,7 +1468,8 @@ export class IAM extends IAMBase {
     subject,
     registrationTypes = [RegistrationTypes.OffChain]
   }: {
-    issuer: string[];
+    // at the moment of requesting there might be no issuers
+    issuer?: string[];
     claim: { claimType: string; claimTypeVersion: number; fields: { key: string; value: string | number }[] };
     subject?: string;
     registrationTypes?: RegistrationTypes[];
@@ -1485,6 +1486,10 @@ export class IAM extends IAMBase {
     // TODO: verfiy onchain
     if (registrationTypes.includes(RegistrationTypes.OffChain)) {
       await this.verifyEnrolmentPreconditions({ subject, role });
+    }
+
+    if (!issuer || issuer.length === 0) {
+      issuer = [`did:${Methods.Erc1056}:${emptyAddress}`];
     }
 
     const message: IClaimRequest = {

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1463,13 +1463,10 @@ export class IAM extends IAMBase {
   }
 
   async createClaimRequest({
-    issuer,
     claim,
     subject,
     registrationTypes = [RegistrationTypes.OffChain]
   }: {
-    // at the moment of requesting there might be no issuers
-    issuer?: string[];
     claim: { claimType: string; claimTypeVersion: number; fields: { key: string; value: string | number }[] };
     subject?: string;
     registrationTypes?: RegistrationTypes[];
@@ -1488,9 +1485,8 @@ export class IAM extends IAMBase {
       await this.verifyEnrolmentPreconditions({ subject, role });
     }
 
-    if (!issuer || issuer.length === 0) {
-      issuer = [`did:${Methods.Erc1056}:${emptyAddress}`];
-    }
+    // temporarily, until claimIssuer is not removed from Claim entity
+    const issuer = [`did:${Methods.Erc1056}:${emptyAddress}`];
 
     const message: IClaimRequest = {
       id: uuid(),

--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -1,5 +1,5 @@
 import { providers, Signer, utils, errors, Wallet } from "ethers";
-import { DomainReader, DomainTransactionFactory, DomainHierarchy, ResolverContractType } from "@energyweb/iam-contracts";
+import { DomainReader, DomainTransactionFactory, DomainHierarchy, ResolverContractType, ClaimManager__factory } from "@energyweb/iam-contracts";
 import { ethrReg, Operator, Resolver } from "@ew-did-registry/did-ethr-resolver";
 import { labelhash, namehash } from "../utils/ENS_hash";
 import { IServiceEndpoint, RegistrySettings, KeyTags, IPublicKey } from "@ew-did-registry/did-resolver-interface";
@@ -649,6 +649,7 @@ export class IAMBase {
       domainNotifierAddress: domainNotifierAddress,
       publicResolverAddress: ensPublicResolverAddress
     });
+    this._claimManager = ClaimManager__factory.connect(claimManagerAddress, this._signer);
 
     const cacheOptions = cacheServerClientOptions[chainId];
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import { utils } from "ethers";
+
 export const emptyAddress = "0x0000000000000000000000000000000000000000";
 export const WALLET_PROVIDER = "WalletProvider";
 export const PUBLIC_KEY = "PublicKey";
@@ -9,3 +11,8 @@ export enum MessagingMethod {
   WebRTC = "webRTC",
   SmartContractStorage = "smartContractStorage"
 }
+
+export const typedMsgPrefix = "1901";
+export const erc712_type_hash = utils.id("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+export const agreement_type_hash = utils.id("Agreement(address subject,bytes32 role,uint256 version)");
+export const proof_type_hash = utils.id("Proof(address subject,bytes32 role,uint256 version,uint256 expiry,address issuer)");

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -16,3 +16,4 @@ export const typedMsgPrefix = "1901";
 export const erc712_type_hash = utils.id("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 export const agreement_type_hash = utils.id("Agreement(address subject,bytes32 role,uint256 version)");
 export const proof_type_hash = utils.id("Proof(address subject,bytes32 role,uint256 version,uint256 expiry,address issuer)");
+export const defaultClaimExpiry = Number.MAX_SAFE_INTEGER;

--- a/src/utils/enrollment.ts
+++ b/src/utils/enrollment.ts
@@ -1,0 +1,9 @@
+export function canonizeSig(sig: string) {
+  let suffix = sig.substr(130);
+  if (suffix === "00") {
+    suffix = "1b";
+  } else if (suffix === "01") {
+    suffix = "1c";
+  }
+  return sig.substr(0, 130) + suffix;
+}

--- a/test/claimsTests/claims.testSuite.ts
+++ b/test/claimsTests/claims.testSuite.ts
@@ -1,5 +1,7 @@
+import { enrollmentClaimsTests } from "./enrollmentClaimsTests";
 import { selfsignedClaimsTests } from "./selfsignedClaimsTests";
 
 export const claimsTests = () => {
   describe("Selfsigned claim tests", selfsignedClaimsTests);
+  describe("Enrollment claims tests", enrollmentClaimsTests);
 };

--- a/test/claimsTests/claims.testSuite.ts
+++ b/test/claimsTests/claims.testSuite.ts
@@ -1,0 +1,5 @@
+import { selfsignedClaimsTests } from "./selfsignedClaimsTests";
+
+export const claimsTests = () => {
+  describe("Selfsigned claim tests", selfsignedClaimsTests);
+};

--- a/test/claimsTests/enrollmentClaimsTests.ts
+++ b/test/claimsTests/enrollmentClaimsTests.ts
@@ -101,19 +101,17 @@ export function enrollmentClaimsTests() {
 
   test("enrollment by issuer of type DID", async () => {
     await subjectIam.createClaimRequest({
-      issuer: [staticIssuerDID],
       claim: { claimType: `${roleName1}.${root}`, claimTypeVersion: version, fields: [] },
       registrationTypes,
       subject: subjectDID
     });
     expect(publish).toBeCalledTimes(1);
-    const [issuerChannel, encodedMsg] = publish.mock.calls.pop();
-    expect(issuerChannel).toEqual(`${staticIssuerDID}.${NATS_EXCHANGE_TOPIC}`);
+    const [, encodedMsg] = publish.mock.calls.pop();
     const message = jsonCodec.decode(encodedMsg);
 
     expect(message).toHaveProperty("id");
     expect(message).toHaveProperty("token");
-    expect(message).toMatchObject({ requester: subjectDID, claimIssuer: [staticIssuerDID], registrationTypes });
+    expect(message).toMatchObject({ requester: subjectDID, registrationTypes });
 
     const { id, agreement: subjectAgreement, token } = message;
     await staticIssuerIam.issueClaimRequest({
@@ -144,7 +142,6 @@ export function enrollmentClaimsTests() {
     });
 
     await dynamicIssuerIam.createClaimRequest({
-      issuer: [staticIssuerDID],
       claim: { claimType: `${roleName1}.${root}`, claimTypeVersion: version, fields: [] },
       registrationTypes,
       subject: dynamicIssuerDID

--- a/test/claimsTests/enrollmentClaimsTests.ts
+++ b/test/claimsTests/enrollmentClaimsTests.ts
@@ -1,0 +1,3 @@
+export const enrollmentClaimsTests = function () {
+
+}

--- a/test/claimsTests/enrollmentClaimsTests.ts
+++ b/test/claimsTests/enrollmentClaimsTests.ts
@@ -1,3 +1,134 @@
-export const enrollmentClaimsTests = function () {
+import { Methods } from "@ew-did-registry/did";
+import { addressOf } from "@ew-did-registry/did-ethr-resolver";
+import { Wallet } from "ethers";
+import { utils } from "ethers";
+import { JSONCodec } from "nats.ws";
+import { IAM, RegistrationTypes } from "../../src/iam";
+import { IRoleDefinition, NATS_EXCHANGE_TOPIC } from "../../src/iam-client-lib";
+import { createIam, root, rootOwner } from "../iam.test";
+import { claimManager } from "../setup_contracts";
 
+const {namehash} = utils;
+
+export function enrollmentClaimsTests() {
+  const issuer = Wallet.createRandom();
+  const issuerDID = `did:${Methods.Erc1056}:${issuer.address}`;
+  const requester = new Wallet(rootOwner.privateKey); // requester owns root
+  const requesterDID = `did:${Methods.Erc1056}:${requester.address}`;
+  const subject = requester;
+  const subjectDID = `did:${Methods.Erc1056}:${subject.address}`;
+  const roleName = "myrole";
+  const namespace = root;
+  const version = 1;
+  const claimType = `${roleName}.${namespace}`;
+  const roleDefinition: IRoleDefinition = {
+    roleName,
+    roleType: "org",
+    fields: [],
+    enrolmentPreconditions: [],
+    issuer: { issuerType: "DID", did: [issuerDID] },
+    version,
+    metadata: {}
+  };
+  const registrationTypes = [RegistrationTypes.OffChain, RegistrationTypes.OnChain];
+  const jsonCodec = JSONCodec();
+  let requesterIam: IAM;
+  let issuerIam: IAM;
+  let publish: jest.Mock;
+  let getDidDocument: jest.Mock;
+  let getRoleDefinition: jest.Mock;
+  let _natsConnection;
+  let _cacheClient;
+  let _jsonCodec;
+
+  beforeAll(async () => {
+    requesterIam = await createIam(requester.privateKey);
+    issuerIam = await createIam(issuer.privateKey);
+
+    await requesterIam.createRole({
+      roleName,
+      namespace,
+      data: roleDefinition,
+      returnSteps: false
+    });
+  });
+
+  beforeAll(() => {
+    ({ _natsConnection, _cacheClient, _jsonCodec } = Reflect.get(IAM, "prototype"));
+    publish = jest.fn().mockImplementation();
+    const mockedNatsConnection = {
+      publish
+    };
+
+    getRoleDefinition = jest.fn().mockImplementation(({ namespace }: { namespace: string }) => {
+      if (namespace === claimType) {
+        return roleDefinition;
+      } else {
+        return undefined;
+      }
+    });
+    getDidDocument = jest.fn().mockImplementation(() => {
+      return { service: {} };
+    });
+    const mockedCacheClient = {
+      getRoleDefinition,
+      getDidDocument
+    };
+
+    Reflect.set(IAM.prototype, "_natsConnection", mockedNatsConnection);
+    Reflect.set(IAM.prototype, "_cacheClient", mockedCacheClient);
+    Reflect.set(IAM.prototype, "_jsonCodec", jsonCodec);
+  });
+
+  afterAll(() => {
+    Reflect.set(IAM.prototype, "_natsConnection", _natsConnection);
+    Reflect.set(IAM.prototype, "_cacheClient", _cacheClient);
+    Reflect.set(IAM.prototype, "_jsonCodec", _jsonCodec);
+  });
+
+  test("enrollment request should be registered", async () => {
+    await requesterIam.createClaimRequest({
+      issuer: [issuerDID],
+      claim: { claimType, claimTypeVersion: version, fields: [] },
+      registrationTypes,
+      subject: subjectDID
+    });
+
+    expect(publish).toBeCalledTimes(1);
+    const channel = publish.mock.calls[0][0];
+    const message = publish.mock.calls[0][1];
+    expect(channel).toEqual(`${issuerDID}.${NATS_EXCHANGE_TOPIC}`);
+    expect(jsonCodec.decode(message)).toHaveProperty("id");
+    expect(jsonCodec.decode(message)).toHaveProperty("token");
+    expect(jsonCodec.decode(message)).toMatchObject({ requester: requesterDID, claimIssuer: [issuerDID], registrationTypes });
+  });
+
+  test("issuing claim request should register on-chain enrollment", async () => {
+    await requesterIam.createClaimRequest({
+      issuer: [issuerDID],
+      claim: { claimType, claimTypeVersion: version, fields: [] },
+      registrationTypes,
+      subject: subjectDID
+    });
+
+    const { id, agreement, token } = jsonCodec.decode(publish.mock.calls.pop()[1]);
+
+    await issuerIam.issueClaimRequest({
+      id,
+      registrationTypes,
+      requester: requesterDID,
+      subjectAgreement: agreement,
+      token
+    });
+
+    const [channel, data] = publish.mock.calls[1];
+    expect(channel).toEqual(`${requesterDID}.${NATS_EXCHANGE_TOPIC}`);
+    
+    const { claimIssuer, requester, onChainProof } = jsonCodec.decode(data);
+    expect(requester).toEqual(requesterDID);
+    expect(claimIssuer).toEqual([issuerDID]);
+    expect(onChainProof).toHaveLength(132);
+    
+    expect(await claimManager.hasRole(addressOf(subjectDID), namehash(`${roleName}.${root}`),version)).toBe(true);
+  });
 }

--- a/test/claimsTests/selfsignedClaimsTests.ts
+++ b/test/claimsTests/selfsignedClaimsTests.ts
@@ -1,6 +1,6 @@
-import { iam } from "./iam.test";
+import { iam } from "../iam.test";
 
-export const claimsTests = () => {
+export const selfsignedClaimsTests = function () {
   const namespace = "daniel.iam.ewc";
 
   test("ens claim can be created", async () => {
@@ -71,4 +71,4 @@ export const claimsTests = () => {
     expect(profile?.name).toBe("Dan");
     expect(updatedService.length).toBe(4);
   });
-};
+}

--- a/test/iam.test.ts
+++ b/test/iam.test.ts
@@ -15,7 +15,7 @@ import { labelhash } from "../src/utils/ENS_hash";
 import { orgTests } from "./organization.testSuite";
 import { appsTests } from "./application.testSuite";
 import { initializeConnectionTests } from "./initializeConnection.testSuite";
-import { claimsTests } from "./claims.testSuite";
+import { claimsTests } from "./claimsTests/claims.testSuite";
 import { setCacheClientOptions, setChainConfig } from "../src/iam/chainConfig";
 import { utilsTests } from "./utilsTests/utils.testSuite";
 import { assetsTests } from "./assets.testsuite";

--- a/test/iam.test.ts
+++ b/test/iam.test.ts
@@ -9,7 +9,8 @@ import {
   GANACHE_PORT,
   assetsManager,
   domainNotifer,
-  claimManager
+  claimManager,
+  replenish
 } from "./setup_contracts";
 import { labelhash } from "../src/utils/ENS_hash";
 import { orgTests } from "./organization.testSuite";
@@ -32,23 +33,9 @@ export const rpcUrl = `http://localhost:${GANACHE_PORT}`;
 
 export const provider = new providers.JsonRpcProvider(rpcUrl);
 
-beforeAll(async () => {
-  // sometimes the transaction are taking more then default 5000 ms jest timeout
-  jest.setTimeout(60000);
-  await deployContracts(privateKey);
-  const chainID = 9;
-  setChainConfig(chainID, {
-    rpcUrl,
-    ensRegistryAddress: ensRegistry.address,
-    ensResolverAddress: ensResolver.address,
-    didContractAddress: didContract.address,
-    assetManagerAddress: assetsManager.address,
-    domainNotifierAddress: domainNotifer.address,
-    claimManagerAddress: claimManager.address
-  });
-  setCacheClientOptions(9, { url: "" });
-
-  iam = new IAM({
+export const createIam = async (privateKey: string) => {
+  await replenish(new Keys({ privateKey }).getAddress());
+  const iam = new IAM({
     rpcUrl,
     privateKey
   });
@@ -59,6 +46,26 @@ beforeAll(async () => {
   } catch (e) {
     console.error(">>> Error initializing connection:", e);
   }
+  return iam;
+};
+
+beforeAll(async () => {
+  // sometimes the transaction are taking more then default 5000 ms jest timeout
+  jest.setTimeout(60000);
+  await deployContracts(privateKey);
+  const chainID = 1;
+  setChainConfig(chainID, {
+    rpcUrl,
+    ensRegistryAddress: ensRegistry.address,
+    ensResolverAddress: ensResolver.address,
+    didContractAddress: didContract.address,
+    assetManagerAddress: assetsManager.address,
+    domainNotifierAddress: domainNotifer.address,
+    claimManagerAddress: claimManager.address
+  });
+  setCacheClientOptions(1, { url: "" });
+
+  iam = await createIam(privateKey);
 });
 
 describe("IAM tests", () => {


### PR DESCRIPTION
https://energyweb.atlassian.net/browse/SWTCH-909

`issuer` parameter of `IAM.requestClaimRequest` changed to optional, because at the moment of requesting there are might not be issuers. To persist request it will be published to empty account channel
Had to set ganache network id to 1, because ganache sets its chain id to network id and it breaks tests
