### PR TITLE
chore(bili): disable minification of output files

### DIFF
--- a/bili.config.ts
+++ b/bili.config.ts
@@ -21,7 +21,7 @@ const config: Config = {
   input: "src/iam-client-lib.ts",
   output: {
     format: ["cjs", "esm"],
-    minify: true
+    minify: false
   }
 };
 


### PR DESCRIPTION
SWTCH-1055 https://energyweb.atlassian.net/browse/SWTCH-1055, fixes issue #195

rationale: minification is only useful for script-tags/CDN and makes debugging and reading stack trace more difficult