### PR TITLE
feature/SWTCH-1112 separate connection to cache server and did registry from iam ininitialization

### DIFF
--- a/src/errors/ErrorMessages.ts
+++ b/src/errors/ErrorMessages.ts
@@ -26,5 +26,6 @@ export enum ERROR_MESSAGES {
   ROLE_PRECONDITION_NOT_MET = "Precondition not met, user not eligible to enrol for a role",
   ROLE_NOT_EXISTS = "Role you want to enroll to does not exists",
   CLAIM_PUBLISHER_NOT_REQUESTER = "Claim subject is not controlled by publisher",
-  ONCHAIN_ROLE_VERSION_NOT_SPECIFIED = "On-chain role version not specified"
+  ONCHAIN_ROLE_VERSION_NOT_SPECIFIED = "On-chain role version not specified",
+  CACHE_SERVER_NOT_REGISTERED = "Cache server for this chain is not registered"
 }

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -170,10 +170,16 @@ export class IAM extends IAMBase {
    */
   async initializeConnection({
     walletProvider = this._providerType,
-    reinitializeMetamask
-  }: { walletProvider?: WalletProvider; reinitializeMetamask?: boolean } = {}): Promise<
-    InitializeData
-  > {
+    reinitializeMetamask,
+    initCacheServer = true,
+    initDID = true
+  }: {
+    walletProvider?: WalletProvider;
+    reinitializeMetamask?: boolean;
+    initCacheServer?: boolean,
+    initDID?: boolean
+  } = {}
+  ): Promise<InitializeData> {
     const { privateKey } = this._connectionOptions;
 
     if (!walletProvider && !privateKey) {
@@ -187,6 +193,12 @@ export class IAM extends IAMBase {
         initializeMetamask: reinitializeMetamask,
         walletProvider
       });
+      if (initCacheServer) {
+        await this.connectToCacheServer();
+      }
+      if (initDID) {
+        await this.connectToDIDRegistry();
+      }
     } catch (err) {
       if (err.message === "User closed modal") {
         return {

--- a/test/application.testSuite.ts
+++ b/test/application.testSuite.ts
@@ -1,5 +1,5 @@
-import { ENSNamespaceTypes, IAM } from "../src/iam";
-import { iam, root, rootOwner } from "./iam.test";
+import { ENSNamespaceTypes } from "../src/iam";
+import { createIam, rootOwnerIam, root, rootOwner } from "./iam.test";
 import { org1 } from "./organization.testSuite";
 import { ensResolver, replenish } from "./setup_contracts";
 import { utils } from "ethers";
@@ -13,61 +13,54 @@ export const appsTests = () => {
 
   test("application can be created", async () => {
     const appDefinition = { appName: "Application 1" };
-    await iam.createApplication({
+    await rootOwnerIam.createApplication({
       appName: app,
       data: appDefinition,
       namespace: `${ENSNamespaceTypes.Application}.${org1}.${root}`
     });
 
-    expect(await iam.checkExistenceOfDomain({ domain: appNode })).toBe(true);
+    expect(await rootOwnerIam.checkExistenceOfDomain({ domain: appNode })).toBe(true);
     expect(
-      await iam.checkExistenceOfDomain({ domain: `${ENSNamespaceTypes.Roles}.${appNode}` })
+      await rootOwnerIam.checkExistenceOfDomain({ domain: `${ENSNamespaceTypes.Roles}.${appNode}` })
     ).toBe(true);
     expect(await ensResolver.name(namehash(appNode))).toBe(appNode);
     expect(
-      await iam.getSubdomains({ domain: `${ENSNamespaceTypes.Application}.${org1}.${root}` })
+      await rootOwnerIam.getSubdomains({ domain: `${ENSNamespaceTypes.Application}.${org1}.${root}` })
     ).toContain(`${app}.${ENSNamespaceTypes.Application}.${org1}.${root}`);
 
-    const readAppDefinition = await iam.getDefinition({ type: ENSNamespaceTypes.Application, namespace: appNode});
+    const readAppDefinition = await rootOwnerIam.getDefinition({ type: ENSNamespaceTypes.Application, namespace: appNode });
     expect(readAppDefinition).toMatchObject(appDefinition);
   });
 
   test("application owner can be changed", async () => {
     const newOwner = new Keys();
     await replenish(newOwner.getAddress());
-    const newOwnerIam = new IAM({
-      rpcUrl: "http://localhost:8544/",
-      privateKey: newOwner.privateKey
-    });
-    await newOwnerIam.initializeConnection({
-      reinitializeMetamask: false,
-      walletProvider: undefined
-    });
+    const newOwnerIam = await createIam(newOwner.privateKey);
 
-    expect(await iam.isOwner({ domain: appNode, user: rootOwner.getAddress() }));
+    expect(await rootOwnerIam.isOwner({ domain: appNode, user: rootOwner.address }));
 
-    await iam.changeAppOwnership({
+    await rootOwnerIam.changeAppOwnership({
       namespace: appNode,
       newOwner: newOwner.getAddress()
     });
 
-    expect(await iam.isOwner({ domain: appNode, user: newOwner.getAddress() }));
+    expect(await rootOwnerIam.isOwner({ domain: appNode, user: newOwner.getAddress() }));
 
     await newOwnerIam.changeAppOwnership({
       namespace: appNode,
-      newOwner: rootOwner.getAddress()
+      newOwner: rootOwner.address
     });
 
-    expect(await iam.isOwner({ domain: appNode, user: rootOwner.getAddress() }));
+    expect(await rootOwnerIam.isOwner({ domain: appNode, user: rootOwner.address }));
   });
 
   test("application can be deleted", async () => {
-    expect(await iam.checkExistenceOfDomain({ domain: appNode })).toBe(true);
+    expect(await rootOwnerIam.checkExistenceOfDomain({ domain: appNode })).toBe(true);
 
-    await iam.deleteApplication({
+    await rootOwnerIam.deleteApplication({
       namespace: appNode
     });
 
-    expect(await iam.checkExistenceOfDomain({ domain: appNode })).toBe(false);
+    expect(await rootOwnerIam.checkExistenceOfDomain({ domain: appNode })).toBe(false);
   });
 };

--- a/test/assets.testsuite.ts
+++ b/test/assets.testsuite.ts
@@ -2,23 +2,29 @@ import { Keys } from "@ew-did-registry/keys";
 import { OfferableIdentityFactory } from "../ethers/OfferableIdentityFactory";
 import { IAM } from "../src/iam";
 import { emptyAddress } from "../src/utils/constants";
-import { iam, provider, rootOwner, rpcUrl } from "./iam.test";
-import { replenish } from "./setup_contracts";
-import { PubKeyType } from '@ew-did-registry/did-resolver-interface/src/models/operator';
-import { Algorithms, DIDAttribute, Encoding } from '@ew-did-registry/did-resolver-interface';
-import { Methods } from '@ew-did-registry/did';
+import { createIam, rootOwner } from "./iam.test";
+import { replenish, provider, rpcUrl } from "./setup_contracts";
+import { PubKeyType } from "@ew-did-registry/did-resolver-interface/src/models/operator";
+import { Algorithms, DIDAttribute, Encoding } from "@ew-did-registry/did-resolver-interface";
+import { Methods } from "@ew-did-registry/did";
 
 export const assetsTests = () => {
+  let rootOwnerIam: IAM;
+
+  beforeAll(async () => {
+    rootOwnerIam = await createIam(rootOwner.privateKey, { initDID: true });
+  });
+
   test("asset should be created", async () => {
-    const assetAddress = await iam.registerAsset();
+    const assetAddress = await rootOwnerIam.registerAsset();
     const assetContract = OfferableIdentityFactory.connect(assetAddress, provider);
     const owner = await assetContract.owner();
-    expect(owner).toBe(rootOwner.getAddress());
+    expect(owner).toBe(rootOwner.address);
   });
   test("asset should be offered", async () => {
-    const assetAddress = await iam.registerAsset();
+    const assetAddress = await rootOwnerIam.registerAsset();
     const newOwner = new Keys();
-    await iam.offerAsset({
+    await rootOwnerIam.offerAsset({
       assetDID: `did:ethr:${assetAddress}`,
       offerTo: `did:ethr:${newOwner.getAddress()}`
     });
@@ -27,31 +33,31 @@ export const assetsTests = () => {
     expect(offered).toBe(newOwner.getAddress());
   });
   test("asset should be able to cancel offer", async () => {
-    const assetAddress = await iam.registerAsset();
+    const assetAddress = await rootOwnerIam.registerAsset();
     const newOwner = new Keys();
     const assetDID = `did:ethr:${assetAddress}`;
-    await iam.offerAsset({
+    await rootOwnerIam.offerAsset({
       assetDID,
       offerTo: `did:ethr:${newOwner.getAddress()}`
     });
     const assetContract = OfferableIdentityFactory.connect(assetAddress, provider);
     const offered = await assetContract.offeredTo();
     expect(offered).toBe(newOwner.getAddress());
-    await iam.cancelAssetOffer({ assetDID });
+    await rootOwnerIam.cancelAssetOffer({ assetDID });
     const notOffered = await assetContract.offeredTo();
     expect(notOffered).toBe(emptyAddress);
   });
   test("asset should be able to accept offer", async () => {
-    const assetAddress = await iam.registerAsset();
+    const assetAddress = await rootOwnerIam.registerAsset();
     const newOwner = new Keys();
     await replenish(newOwner.getAddress());
     const assetDID = `did:ethr:${assetAddress}`;
-    await iam.offerAsset({ assetDID, offerTo: `did:ethr:${newOwner.getAddress()}` });
+    await rootOwnerIam.offerAsset({ assetDID, offerTo: `did:ethr:${newOwner.getAddress()}` });
     const newOwnerIAM = new IAM({
       privateKey: newOwner.privateKey,
-      rpcUrl
+      rpcUrl,
     });
-    await newOwnerIAM.initializeConnection();
+    await newOwnerIAM.initializeConnection({ initCacheServer: false, initDID: false });
     await newOwnerIAM.acceptAssetOffer({
       assetDID
     });
@@ -63,49 +69,49 @@ export const assetsTests = () => {
   });
 
   test("asset should be able to reject offer", async () => {
-    const assetAddress = await iam.registerAsset();
+    const assetAddress = await rootOwnerIam.registerAsset();
     const newOwner = new Keys();
     await replenish(newOwner.getAddress());
     const assetDID = `did:ethr:${assetAddress}`;
-    await iam.offerAsset({ assetDID, offerTo: `did:ethr:${newOwner.getAddress()}` });
+    await rootOwnerIam.offerAsset({ assetDID, offerTo: `did:ethr:${newOwner.getAddress()}` });
     const newOwnerIAM = new IAM({
       privateKey: newOwner.privateKey,
       rpcUrl
     });
-    await newOwnerIAM.initializeConnection();
+    await newOwnerIAM.initializeConnection({ initCacheServer: false, initDID: false });
     await newOwnerIAM.rejectAssetOffer({
       assetDID
     });
     const assetContract = OfferableIdentityFactory.connect(assetAddress, provider);
     const owner = await assetContract.owner();
     const offeredTo = await assetContract.offeredTo();
-    expect(owner).toBe(rootOwner.getAddress());
+    expect(owner).toBe(rootOwner.address);
     expect(offeredTo).toBe(emptyAddress);
   });
 
   test("update did document for asset", async () => {
-    const assetAddress = await iam.registerAsset();
+    const assetAddress = await rootOwnerIam.registerAsset();
 
-    const asset1 = await iam.getDidDocument({ did: `did:${Methods.Erc1056}:${assetAddress}` });
+    const asset1 = await rootOwnerIam.getDidDocument({ did: `did:${Methods.Erc1056}:${assetAddress}` });
     expect(asset1.publicKey.length).toBe(0);
 
-    const update = await iam.updateDidDocument({
+    const update = await rootOwnerIam.updateDidDocument({
       didAttribute: DIDAttribute.PublicKey,
       did: `did:ethr:${assetAddress}`,
       data: {
         algo: Algorithms.Secp256k1,
         encoding: Encoding.HEX,
         type: PubKeyType.SignatureAuthentication2018,
-        value: { tag: 'key-1', publicKey: `0x${new Keys().publicKey}` }
+        value: { tag: "key-1", publicKey: `0x${new Keys().publicKey}` }
       }
     });
     expect(update).toBeTruthy();
 
-    const asset = await iam.getDidDocument({ did: `did:${Methods.Erc1056}:${assetAddress}` });
+    const asset = await rootOwnerIam.getDidDocument({ did: `did:${Methods.Erc1056}:${assetAddress}` });
     expect(asset.publicKey.length).toBe(1);
 
     const did = `did:${Methods.Erc1056}:${assetAddress}#key-1`;
-    const type = 'Secp256k1sigAuth';
+    const type = "Secp256k1sigAuth";
     expect(asset.publicKey.find((asset) => asset.id === did && asset.type === type)).toBeTruthy();
   });
 };

--- a/test/claimsTests/enrollmentClaimsTests.ts
+++ b/test/claimsTests/enrollmentClaimsTests.ts
@@ -6,7 +6,7 @@ import { JSONCodec } from "nats.ws";
 import { IAM, RegistrationTypes } from "../../src/iam";
 import { IRoleDefinition, NATS_EXCHANGE_TOPIC } from "../../src/iam-client-lib";
 import { createIam, root, rootOwner } from "../iam.test";
-import { claimManager } from "../setup_contracts";
+import { claimManager, replenish } from "../setup_contracts";
 
 const { namehash } = utils;
 
@@ -15,7 +15,7 @@ export function enrollmentClaimsTests() {
   const staticIssuerDID = `did:${Methods.Erc1056}:${staticIissuer.address}`;
   const dynamicIssuer = Wallet.createRandom();
   const dynamicIssuerDID = `did:${Methods.Erc1056}:${dynamicIssuer.address}`;
-  const roleCreator = new Wallet(rootOwner.privateKey); // owns root
+  const roleCreator = rootOwner; // owns root
   const roleCreatorDID = `did:${Methods.Erc1056}:${roleCreator.address}`;
   const subject = roleCreator;
   const subjectDID = `did:${Methods.Erc1056}:${subject.address}`;
@@ -50,10 +50,13 @@ export function enrollmentClaimsTests() {
   let _jsonCodec;
 
   beforeAll(async () => {
-    roleCreatorIam = await createIam(roleCreator.privateKey);
-    subjectIam = await createIam(subject.privateKey);
-    staticIssuerIam = await createIam(staticIissuer.privateKey);
-    dynamicIssuerIam = await createIam(dynamicIssuer.privateKey);
+    await replenish(roleCreator.address);
+    roleCreatorIam = await createIam(roleCreator.privateKey, { initDID: true });
+    subjectIam = await createIam(subject.privateKey, { initDID: true });
+    await replenish(staticIissuer.address);
+    staticIssuerIam = await createIam(staticIissuer.privateKey, { initDID: true });
+    await replenish(dynamicIssuer.address);
+    dynamicIssuerIam = await createIam(dynamicIssuer.privateKey, { initDID: true });
 
     await roleCreatorIam.createRole({
       roleName: roleName1,

--- a/test/claimsTests/selfsignedClaimsTests.ts
+++ b/test/claimsTests/selfsignedClaimsTests.ts
@@ -1,21 +1,37 @@
-import { iam } from "../iam.test";
+import { IAM } from "../../src/iam";
+import { rootOwner } from "../iam.test";
+import { rpcUrl } from "../setup_contracts";
 
 export const selfsignedClaimsTests = function () {
+  let rootOwnerIam: IAM;
+
   const namespace = "daniel.iam.ewc";
 
+  beforeAll(async () => {
+    rootOwnerIam = new IAM({
+      rpcUrl,
+      privateKey: rootOwner.privateKey
+    });
+    await rootOwnerIam.initializeConnection({
+      reinitializeMetamask: false,
+      initCacheServer: false,
+      initDID: true
+    });
+  });
+
   test("ens claim can be created", async () => {
-    await iam.createSelfSignedClaim({
+    await rootOwnerIam.createSelfSignedClaim({
       data: { claimType: namespace, claimTypeVersion: 1 }
     });
-    const { service = [] } = await iam.getDidDocument();
+    const { service = [] } = await rootOwnerIam.getDidDocument();
     expect(service.find(({ claimType }) => claimType === namespace)).toBeTruthy();
   });
   test("ens claim should by updated", async () => {
-    const { service = [] } = await iam.getDidDocument();
+    const { service = [] } = await rootOwnerIam.getDidDocument();
     const { claimType, claimTypeVersion } =
       service.find(({ claimType }) => claimType === namespace) || {};
-    await iam.createSelfSignedClaim({ data: { claimType, claimTypeVersion } });
-    const { service: newServices = [] } = await iam.getDidDocument();
+    await rootOwnerIam.createSelfSignedClaim({ data: { claimType, claimTypeVersion } });
+    const { service: newServices = [] } = await rootOwnerIam.getDidDocument();
     expect(
       newServices.find(
         claim => claim.claimType === claimType && claim.claimTypeVersion === claimTypeVersion
@@ -24,12 +40,12 @@ export const selfsignedClaimsTests = function () {
     expect(newServices.length).toBe(1);
   });
   test("ens claim should be created when claimType do not match", async () => {
-    const { service = [] } = await iam.getDidDocument();
+    const { service = [] } = await rootOwnerIam.getDidDocument();
     const { claimTypeVersion } = service.find(({ claimType }) => claimType === namespace) || {};
-    await iam.createSelfSignedClaim({
+    await rootOwnerIam.createSelfSignedClaim({
       data: { claimType: "edvin.iam.ewc", claimTypeVersion }
     });
-    const { service: newServices = [] } = await iam.getDidDocument();
+    const { service: newServices = [] } = await rootOwnerIam.getDidDocument();
     expect(
       newServices.find(
         claim => claim.claimType === "edvin.iam.ewc" && claim.claimTypeVersion === claimTypeVersion
@@ -38,35 +54,35 @@ export const selfsignedClaimsTests = function () {
     expect(newServices.length).toBe(2);
   });
   test("ens claim should be created when claimTypeVersion do not match", async () => {
-    await iam.createSelfSignedClaim({
+    await rootOwnerIam.createSelfSignedClaim({
       data: { claimType: namespace, claimTypeVersion: 2 }
     });
-    const { service: newServices = [] } = await iam.getDidDocument();
+    const { service: newServices = [] } = await rootOwnerIam.getDidDocument();
     expect(
       newServices.find(claim => claim.claimType === namespace && claim.claimTypeVersion === 2)
     ).toBeTruthy();
     expect(newServices.length).toBe(3);
   });
   test("ens claim should not be created", async () => {
-    await iam.createSelfSignedClaim({
+    await rootOwnerIam.createSelfSignedClaim({
       data: { claimType: namespace, claimTypeVersion: 2 }
     });
-    const { service: newServices = [] } = await iam.getDidDocument();
+    const { service: newServices = [] } = await rootOwnerIam.getDidDocument();
     expect(newServices.length).toBe(3);
   });
 
   test("profile claim should be created", async () => {
-    await iam.createSelfSignedClaim({
+    await rootOwnerIam.createSelfSignedClaim({
       data: { profile: { name: "Edwin" } }
     });
-    const { service = [] } = await iam.getDidDocument();
+    const { service = [] } = await rootOwnerIam.getDidDocument();
     expect(service.find(claim => claim.profile && claim.profile.name === "Edwin")).toBeTruthy();
   });
   test("profile claim should be updated", async () => {
-    const { service = [] } = await iam.getDidDocument();
+    const { service = [] } = await rootOwnerIam.getDidDocument();
     const { id } = service.find(({ profile }) => Boolean(profile)) || {};
-    await iam.createSelfSignedClaim({ data: { profile: { name: "Dan" } } });
-    const { service: updatedService = [] } = await iam.getDidDocument();
+    await rootOwnerIam.createSelfSignedClaim({ data: { profile: { name: "Dan" } } });
+    const { service: updatedService = [] } = await rootOwnerIam.getDidDocument();
     const { profile } = updatedService.find(({ id: claimId }) => id === claimId) || {};
     expect(profile?.name).toBe("Dan");
     expect(updatedService.length).toBe(4);

--- a/test/iam.test.ts
+++ b/test/iam.test.ts
@@ -1,16 +1,19 @@
-import { providers, utils } from "ethers";
-import { Keys } from "@ew-did-registry/keys";
+import { utils, Wallet } from "ethers";
 import { IAM, ENSNamespaceTypes } from "../src/iam";
 import {
-  deployContracts,
+  deployDidRegistry,
   ensRegistry,
   ensResolver,
   didContract,
-  GANACHE_PORT,
+  rpcUrl,
   assetsManager,
   domainNotifer,
   claimManager,
-  replenish
+  replenish,
+  deployEns,
+  provider,
+  deployIdentityManager,
+  deployClaimManager
 } from "./setup_contracts";
 import { labelhash } from "../src/utils/ENS_hash";
 import { orgTests } from "./organization.testSuite";
@@ -23,25 +26,21 @@ import { assetsTests } from "./assets.testsuite";
 
 const { namehash, bigNumberify } = utils;
 
-export const rootOwner = new Keys();
-const { privateKey } = rootOwner;
+export const rootOwner = Wallet.createRandom().connect(provider);
 
 export const root = "root";
-export let iam: IAM;
+export let rootOwnerIam: IAM;
 
-export const rpcUrl = `http://localhost:${GANACHE_PORT}`;
-
-export const provider = new providers.JsonRpcProvider(rpcUrl);
-
-export const createIam = async (privateKey: string) => {
-  await replenish(new Keys({ privateKey }).getAddress());
+export const createIam = async (privateKey: string, { initCacheServer = false, initDID = false } = {}) => {
   const iam = new IAM({
     rpcUrl,
     privateKey
   });
   try {
     await iam.initializeConnection({
-      reinitializeMetamask: false
+      reinitializeMetamask: false,
+      initCacheServer,
+      initDID
     });
   } catch (e) {
     console.error(">>> Error initializing connection:", e);
@@ -50,11 +49,16 @@ export const createIam = async (privateKey: string) => {
 };
 
 beforeAll(async () => {
-  // sometimes the transaction are taking more then default 5000 ms jest timeout
+  // sometimes transaction is taking more then default 5000 ms jest timeout
   jest.setTimeout(60000);
-  await deployContracts(privateKey);
-  const chainID = 1;
-  setChainConfig(chainID, {
+  const deployer = rootOwner.connect(provider);
+  await replenish(deployer.address);
+  await deployDidRegistry();
+  await deployEns();
+  await deployIdentityManager();
+  await deployClaimManager();
+  const { chainId } = await provider.getNetwork();
+  setChainConfig(chainId, {
     rpcUrl,
     ensRegistryAddress: ensRegistry.address,
     ensResolverAddress: ensResolver.address,
@@ -63,34 +67,38 @@ beforeAll(async () => {
     domainNotifierAddress: domainNotifer.address,
     claimManagerAddress: claimManager.address
   });
-  setCacheClientOptions(1, { url: "" });
+  setCacheClientOptions(chainId, { url: "" });
 
-  iam = await createIam(privateKey);
+  await replenish(rootOwner.address);
+  rootOwnerIam = await createIam(rootOwner.privateKey);
 });
 
+/**
+   * @todo should be refactored because some tests depends on 'create root node'
+   */
 describe("IAM tests", () => {
   test("can create root node", async () => {
     const tx = await ensRegistry.setSubnodeRecord(
       namehash(""),
       labelhash(root),
-      rootOwner.getAddress(),
+      rootOwner.address,
       ensResolver.address,
       bigNumberify(0)
     );
     await tx.wait();
 
-    expect(await iam.checkExistenceOfDomain({ domain: root })).toBe(true);
-    expect(await iam.isOwner({ domain: root, user: rootOwner.getAddress() }));
+    expect(await rootOwnerIam.checkExistenceOfDomain({ domain: root })).toBe(true);
+    expect(await rootOwnerIam.isOwner({ domain: root, user: rootOwner.address }));
     expect(
-      await iam.isOwner({
+      await rootOwnerIam.isOwner({
         domain: `${ENSNamespaceTypes.Application}.${root}`,
-        user: rootOwner.getAddress()
+        user: rootOwner.address
       })
     );
     expect(
-      await iam.isOwner({
+      await rootOwnerIam.isOwner({
         domain: `${ENSNamespaceTypes.Roles}.${root}`,
-        user: rootOwner.getAddress()
+        user: rootOwner.address
       })
     );
   });

--- a/test/initializeConnection.testSuite.ts
+++ b/test/initializeConnection.testSuite.ts
@@ -1,6 +1,6 @@
 import { IAM } from "../src/iam";
 import { ERROR_MESSAGES } from "../src/errors";
-import { rpcUrl } from "./iam.test";
+import { rpcUrl } from "./setup_contracts";
 import { WalletProvider } from "../src/types/WalletProvider";
 
 const iam_withoutKey = new IAM({ rpcUrl });

--- a/test/utilsTests/changeResolver.testSuite.ts
+++ b/test/utilsTests/changeResolver.testSuite.ts
@@ -1,21 +1,20 @@
 import { DomainHierarchy, DomainReader, RoleDefinitionResolver__factory, DomainNotifier__factory, ResolverContractType } from "@energyweb/iam-contracts";
-import { changeResolver, ChangeResolverParams } from '../../src/utils/change_resolver';
-import { root, rootOwner, rpcUrl } from '../iam.test';
-import { org1 } from '../organization.testSuite';
-import { ensRegistry, ensResolver, provider } from '../setup_contracts';
-import { NODE_FIELDS_KEY } from '../../src/utils/constants';
-import { Contract, Wallet, utils } from 'ethers';
+import { changeResolver, ChangeResolverParams } from "../../src/utils/change_resolver";
+import { root, rootOwner } from "../iam.test";
+import { org1 } from "../organization.testSuite";
+import { ensRegistry, ensResolver, provider, rpcUrl } from "../setup_contracts";
+import { NODE_FIELDS_KEY } from "../../src/utils/constants";
+import { Contract, utils } from "ethers";
 
 export const changeResolverTests = () => {
   let newResolverAddr: string;
   let newResolver: Contract;
-  let params: Omit<ChangeResolverParams, 'rootNode'>;
+  let params: Omit<ChangeResolverParams, "rootNode">;
   let domainHierarchy: DomainHierarchy;
 
   beforeAll(async () => {
-    const wallet = new Wallet(rootOwner.privateKey, provider);
-    const domainNotifer = await new DomainNotifier__factory(wallet).deploy(ensRegistry.address);
-    newResolver = await new RoleDefinitionResolver__factory(wallet).deploy(ensRegistry.address, domainNotifer.address);
+    const domainNotifer = await new DomainNotifier__factory(rootOwner).deploy(ensRegistry.address);
+    newResolver = await new RoleDefinitionResolver__factory(rootOwner).deploy(ensRegistry.address, domainNotifer.address);
     newResolverAddr = newResolver.address;
     const domainReader = new DomainReader({
       ensRegistryAddress: ensRegistry.address,
@@ -40,7 +39,7 @@ export const changeResolverTests = () => {
     };
   });
 
-  test('org domain resolver can be changed', async () => {
+  test("org domain resolver can be changed", async () => {
     const rootNode = `${org1}.${root}`;
 
     await changeResolver({ ...params, rootNode });
@@ -54,11 +53,11 @@ export const changeResolverTests = () => {
       .toBe(true);
   });
 
-  test('root resolver can be changed', async () => {
+  test("root resolver can be changed", async () => {
     const rootNode = `${root}`;
 
-    await ensRegistry.setOwner(utils.namehash('org1-1.org1.root'), '0xE45Ad1e7522288588dA6829A9ea6A09e92FCDe14');
-    await ensRegistry.setOwner(utils.namehash('org1.root'), '0xE45Ad1e7522288588dA6829A9ea6A09e92FCDe14');
+    await ensRegistry.connect(rootOwner).setOwner(utils.namehash("org1-1.org1.root"), "0xE45Ad1e7522288588dA6829A9ea6A09e92FCDe14");
+    await ensRegistry.connect(rootOwner).setOwner(utils.namehash("org1.root"), "0xE45Ad1e7522288588dA6829A9ea6A09e92FCDe14");
 
     await changeResolver({ ...params, rootNode });
 


### PR DESCRIPTION
- Connecting to cache server and DID registry are moved to `connectToCacheServer` and `connectToDID`. These methods can be invoked after iam initialization or as part of it by setting additional initialization flags `initCacheServer` and `initDID`