### PR TITLE
fix: throwing an error when initializing wallet provider.

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -211,7 +211,7 @@ export class IAM extends IAMBase {
                     realtimeExchangeConnected: false,
                 };
             }
-            throw new Error(err);
+            throw new Error(err.message);
         }
 
         return {


### PR DESCRIPTION
In switchboard when error occurs in metamask while login we get error `[object Object]` like on the screen
![image](https://user-images.githubusercontent.com/83639710/129167175-74ec5ffb-2ab2-4fb5-876b-e2509604cd0a.png)
This happens when:
1. User cancel operation
2. User have pending interactions.

Fix solves this problem, so in switchboard we will have meaningful messages.