### PR TITLE
fix: setting session in local storage after successful login.

### DIFF
--- a/src/iam/iam-base.ts
+++ b/src/iam/iam-base.ts
@@ -163,7 +163,6 @@ export class IAMBase {
 
         this.setResolver();
         this.setJWT();
-        this.storeSession();
     }
 
     private async initSigner({
@@ -274,6 +273,7 @@ export class IAMBase {
         this._didSigner = new Owner(this._signer, this._provider, this._publicKey);
         await this.setDocument();
         this.setClaims();
+        this.storeSession();
     }
 
     /**


### PR DESCRIPTION
Method `storeSession` was called before setting `_didSigner` property. This PR solves this problem, we set session storage after setting didSigner.