### PR TITLE
Rename verifyPublicToken param name

### DIFF
--- a/docs/api/classes/GnosisIam.GnosisIam-1.md
+++ b/docs/api/classes/GnosisIam.GnosisIam-1.md
@@ -1680,12 +1680,14 @@ verifyPublicClaim
 
 **`description`** verifies issued token of claim
 
+**`throws`** if the proof failed
+
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `__namedParameters` | `Object` |
-| `__namedParameters.issuedToken` | `string` |
+| `__namedParameters.claimUrl` | `string` |
 
 #### Returns
 

--- a/docs/api/classes/iam.IAM.md
+++ b/docs/api/classes/iam.IAM.md
@@ -1441,12 +1441,14 @@ verifyPublicClaim
 
 **`description`** verifies issued token of claim
 
+**`throws`** if the proof failed
+
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `__namedParameters` | `Object` |
-| `__namedParameters.issuedToken` | `string` |
+| `__namedParameters.claimUrl` | `string` |
 
 #### Returns
 

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -494,12 +494,13 @@ export class IAM extends IAMBase {
      * verifyPublicClaim
      *
      * @description verifies issued token of claim
-     * @returns public claim data
+     * @returns { Promise<IPublicClaim> } public claim data
+     * @throws if the proof failed
      *
      */
-    async verifyPublicClaim({ issuedToken }: { issuedToken: string }) {
+    async verifyPublicClaim({ claimUrl }: { claimUrl: string }) {
         if (this._verifierClaims) {
-            return this._verifierClaims.verifyPublicProof(issuedToken);
+            return this._verifierClaims.verifyPublicProof(claimUrl);
         }
         throw new Error(ERROR_MESSAGES.CLAIMS_NOT_INITIALIZED);
     }


### PR DESCRIPTION
BREAKING CHANGE: Rename the prop name from `issuedToken` to `claimUrl` in method `verifyPublicClaim` in `IAM` class.