### PR TITLE
refactor!: drop support for DID format when offering asset. Use address instead

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -1809,9 +1809,8 @@ export class IAM extends IAMBase {
         if (!this._address) {
             throw new Error(ERROR_MESSAGES.USER_NOT_LOGGED_IN);
         }
-        const [, , offerToAddress] = offerTo.split(":");
         const [, , assetContractAddress] = assetDID.split(":");
-        const tx = this.offerAssetTx({ assetContractAddress, offerTo: offerToAddress });
+        const tx = this.offerAssetTx({ assetContractAddress, offerTo });
         await this.send({
             calls: [tx],
             from: this._address,

--- a/test/assets.testsuite.ts
+++ b/test/assets.testsuite.ts
@@ -26,7 +26,7 @@ export const assetsTests = () => {
         const newOwner = new Keys();
         await rootOwnerIam.offerAsset({
             assetDID: `did:ethr:${assetAddress}`,
-            offerTo: `did:ethr:${newOwner.getAddress()}`,
+            offerTo: `${newOwner.getAddress()}`,
         });
         const assetContract = OfferableIdentity__factory.connect(assetAddress, provider);
         const offered = await assetContract.offeredTo();
@@ -38,7 +38,7 @@ export const assetsTests = () => {
         const assetDID = `did:ethr:${assetAddress}`;
         await rootOwnerIam.offerAsset({
             assetDID,
-            offerTo: `did:ethr:${newOwner.getAddress()}`,
+            offerTo: `${newOwner.getAddress()}`,
         });
         const assetContract = OfferableIdentity__factory.connect(assetAddress, provider);
         const offered = await assetContract.offeredTo();
@@ -52,7 +52,7 @@ export const assetsTests = () => {
         const newOwner = new Keys();
         await replenish(newOwner.getAddress());
         const assetDID = `did:ethr:${assetAddress}`;
-        await rootOwnerIam.offerAsset({ assetDID, offerTo: `did:ethr:${newOwner.getAddress()}` });
+        await rootOwnerIam.offerAsset({ assetDID, offerTo: `${newOwner.getAddress()}` });
         const newOwnerIAM = new IAM({
             privateKey: newOwner.privateKey,
             rpcUrl,
@@ -73,7 +73,7 @@ export const assetsTests = () => {
         const newOwner = new Keys();
         await replenish(newOwner.getAddress());
         const assetDID = `did:ethr:${assetAddress}`;
-        await rootOwnerIam.offerAsset({ assetDID, offerTo: `did:ethr:${newOwner.getAddress()}` });
+        await rootOwnerIam.offerAsset({ assetDID, offerTo: `${newOwner.getAddress()}` });
         const newOwnerIAM = new IAM({
             privateKey: newOwner.privateKey,
             rpcUrl,


### PR DESCRIPTION
While offering asset to other user let's use address instead of did format.