### PR TITLE
fix: detecting execution environment, when browser have declared global property.

### DIFF
--- a/docs/api/modules/utils_detectEnvironment.md
+++ b/docs/api/modules/utils_detectEnvironment.md
@@ -14,8 +14,8 @@
 
 ### detectExecutionEnvironment
 
-▸ `Const` **detectExecutionEnvironment**(): `any`
+▸ `Const` **detectExecutionEnvironment**(): `ExecutionEnvironment`
 
 #### Returns
 
-`any`
+`ExecutionEnvironment`

--- a/src/utils/detectEnvironment.ts
+++ b/src/utils/detectEnvironment.ts
@@ -4,8 +4,8 @@ export enum ExecutionEnvironment {
 }
 
 export const detectExecutionEnvironment = () =>
-    (isNode() && ExecutionEnvironment.NODE) || (isBrowser() && ExecutionEnvironment.BROWSER);
+    isNode() && !isBrowser() ? ExecutionEnvironment.NODE : ExecutionEnvironment.BROWSER;
 
-const isNode = new Function("try { return this === global } catch(e) { return false; }");
+const isNode = () => typeof process !== "undefined" && process.versions != null && process.versions.node != null;
 
-const isBrowser = new Function("try { return this === window } catch(e) { return false; }");
+const isBrowser = () => typeof window !== "undefined" && typeof window.document !== "undefined";


### PR DESCRIPTION
To use library with newest version of angular and webpack 5 i need to specify global property `(window as any)['global'] = window;`. Because of that, IAM sets `_executionEnvironment` as NODE, which is wrong.