### PR TITLE
feat/ICL-109: allow to use private key to login in browser env

### DIFF
--- a/docs/api/classes/GnosisIam.GnosisIam-1.md
+++ b/docs/api/classes/GnosisIam.GnosisIam-1.md
@@ -1041,13 +1041,13 @@ ___
 
 ### getProviderType
 
-▸ **getProviderType**(): `undefined` \| [`WalletProvider`](../enums/types_WalletProvider.WalletProvider.md)
+▸ **getProviderType**(): [`WalletProvider`](../enums/types_WalletProvider.WalletProvider.md)
 
 Get the current initialized provider type
 
 #### Returns
 
-`undefined` \| [`WalletProvider`](../enums/types_WalletProvider.WalletProvider.md)
+[`WalletProvider`](../enums/types_WalletProvider.WalletProvider.md)
 
 provider type if the session is active if not undefined
 

--- a/docs/api/classes/iam.IAM.md
+++ b/docs/api/classes/iam.IAM.md
@@ -893,13 +893,13 @@ ___
 
 ### getProviderType
 
-▸ **getProviderType**(): `undefined` \| [`WalletProvider`](../enums/types_WalletProvider.WalletProvider.md)
+▸ **getProviderType**(): [`WalletProvider`](../enums/types_WalletProvider.WalletProvider.md)
 
 Get the current initialized provider type
 
 #### Returns
 
-`undefined` \| [`WalletProvider`](../enums/types_WalletProvider.WalletProvider.md)
+[`WalletProvider`](../enums/types_WalletProvider.WalletProvider.md)
 
 provider type if the session is active if not undefined
 

--- a/docs/api/enums/types_WalletProvider.WalletProvider.md
+++ b/docs/api/enums/types_WalletProvider.WalletProvider.md
@@ -8,6 +8,7 @@
 
 - [EwKeyManager](types_WalletProvider.WalletProvider.md#ewkeymanager)
 - [MetaMask](types_WalletProvider.WalletProvider.md#metamask)
+- [PrivateKey](types_WalletProvider.WalletProvider.md#privatekey)
 - [WalletConnect](types_WalletProvider.WalletProvider.md#walletconnect)
 
 ## Enumeration members
@@ -21,6 +22,12 @@ ___
 ### MetaMask
 
 • **MetaMask** = `"MetaMask"`
+
+___
+
+### PrivateKey
+
+• **PrivateKey** = `"PrivateKey"`
 
 ___
 

--- a/src/types/WalletProvider.ts
+++ b/src/types/WalletProvider.ts
@@ -2,4 +2,5 @@ export enum WalletProvider {
     WalletConnect = "WalletConnect",
     MetaMask = "MetaMask",
     EwKeyManager = "EwKeyManager",
+    PrivateKey = "PrivateKey",
 }

--- a/test/initializeConnection.testSuite.ts
+++ b/test/initializeConnection.testSuite.ts
@@ -6,8 +6,8 @@ import { WalletProvider } from "../src/types/WalletProvider";
 const iam_withoutKey = new IAM({ rpcUrl });
 
 export const initializeConnectionTests = () => {
-    test("initializeConnection requires privateKey or walletProvider enum", async () => {
-        await expect(iam_withoutKey.initializeConnection()).rejects.toThrow(ERROR_MESSAGES.WALLET_TYPE_NOT_PROVIDED);
+    test("initializeConnection requires privateKey", async () => {
+        await expect(iam_withoutKey.initializeConnection()).rejects.toThrow(ERROR_MESSAGES.PRIVATE_KEY_NOT_PROVIDED);
     });
 
     test("initializeConnection requires walletProvider to be known value", async () => {


### PR DESCRIPTION
This change allows to use private key to login through frontend application. Current implementation allows to use private key to login only in Node env. This is needed to start e2e testing with private key, to omit metamask login.