### PR TITLE
fix(doc): package.json with correct version

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -44,12 +44,12 @@
                 "changelogFile": "docs/CHANGELOG.md"
             }
         ],
+        "@semantic-release/npm",
         [
             "@semantic-release/git",
             {
-                "assets": ["docs/CHANGELOG.md"]
+                "assets": ["package.json", "docs/CHANGELOG.md"]
             }
-        ],
-        "@semantic-release/npm"
+        ]
     ]
 }


### PR DESCRIPTION
- semantic release packages order change - npm before git
- add package.json to git assets