### PR TITLE
ci(github.actions): fix ownership of develop head file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,5 +66,6 @@ jobs:
       - name: Commit to develop branch and merge to master branch
         run: |
           git checkout develop
+          sudo chown $(id -u) .git/logs/refs/heads/develop
           git merge origin/master
           git push origin develop


### PR DESCRIPTION
According to docs:
>The Linux and macOS virtual machines both run using passwordless sudo. When you need to execute commands or install tools that require more privileges than the current user, you can use sudo without needing to provide a password.

>This is usually caused by running a checkout in a docker container in one job, and then running checkout again in another job, but not in a container. The files created by the checkout in the first containerized job will be owned by root, leaving the second job unable to change those files. This also happens with checkout V2

By doing `git checkout develop` at line `69` outside of `actions/checkout@v2` we are losing permissions to `.git` directory. 
I'm not really sure if this will work but let's try.

References:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#about-virtual-environments
https://github.community/t/how-to-run-actions-checkout-v1-with-sudo-privileges/17436/11
