### PR TITLE
chore(dependabot): initial dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "npm"
+      - "dependencies"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "JGiter"
+      - "jrhender"


### PR DESCRIPTION
@JGiter we need to enable dependabot in settings
@jrhender can you confirm who needs to be notified about pull-requests made from dependabot?