### PR TITLE
bug/SWTCH-1250 Switchboard doesn't relogin on changing Metamask account

### DIFF
--- a/docs/api/classes/modules_signer_signer_service.SignerService.md
+++ b/docs/api/classes/modules_signer_signer_service.SignerService.md
@@ -23,6 +23,7 @@
 - [balance](modules_signer_signer_service.SignerService.md#balance)
 - [closeConnection](modules_signer_signer_service.SignerService.md#closeconnection)
 - [connect](modules_signer_signer_service.SignerService.md#connect)
+- [emit](modules_signer_signer_service.SignerService.md#emit)
 - [init](modules_signer_signer_service.SignerService.md#init)
 - [initEventHandlers](modules_signer_signer_service.SignerService.md#initeventhandlers)
 - [on](modules_signer_signer_service.SignerService.md#on)
@@ -147,6 +148,22 @@ ___
 | :------ | :------ |
 | `signer` | `Required`<`Signer`\> |
 | `providerType` | [`ProviderType`](../enums/modules_signer_signer_types.ProviderType.md) |
+
+#### Returns
+
+`Promise`<`void`\>
+
+___
+
+### emit
+
+▸ **emit**(`e`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `e` | [`ProviderEvent`](../enums/modules_signer_signer_types.ProviderEvent.md) |
 
 #### Returns
 

--- a/docs/api/enums/modules_signer_signer_types.ProviderEvent.md
+++ b/docs/api/enums/modules_signer_signer_types.ProviderEvent.md
@@ -17,11 +17,15 @@
 
 • **AccountChanged** = `"accountsChanged"`
 
+Metamask events https://docs.metamask.io/guide/ethereum-provider.html#events
+
 ___
 
 ### Disconnected
 
 • **Disconnected** = `"disconnect"`
+
+WalletConnect events https://docs.walletconnect.com/1.0/client-api#register-event-subscription
 
 ___
 

--- a/docs/api/enums/modules_signer_signer_types.ProviderEvent.md
+++ b/docs/api/enums/modules_signer_signer_types.ProviderEvent.md
@@ -15,13 +15,13 @@
 
 ### AccountChanged
 
-• **AccountChanged** = `"accountChanged"`
+• **AccountChanged** = `"accountsChanged"`
 
 ___
 
 ### Disconnected
 
-• **Disconnected** = `"disconnected"`
+• **Disconnected** = `"disconnect"`
 
 ___
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "iam-client-lib",
-    "version": "3.3.0-alpha.9",
+    "version": "3.3.0-alpha.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/modules/signer/signer.service.ts
+++ b/src/modules/signer/signer.service.ts
@@ -55,11 +55,13 @@ export class SignerService {
     }
 
     async emit(e: ProviderEvent) {
-        for await (const { event, cb } of this._walletEventListeners) {
-            if (event === e) {
-                await cb();
-            }
-        }
+        await Promise.all(
+            this._walletEventListeners
+                .map(({ event, cb }) => {
+                    return e === event ? cb() : null;
+                })
+                .filter(Boolean),
+        );
     }
 
     on(event: ProviderEvent, cb) {
@@ -80,7 +82,7 @@ export class SignerService {
             this.on(ProviderEvent.NetworkChanged, accChangedHandler);
         } else if (this._providerType === ProviderType.WalletConnect) {
             this.on(ProviderEvent.SessionUpdate, accChangedHandler);
-            this.on(ProviderEvent.Disconnected, this.closeConnection());
+            this.on(ProviderEvent.Disconnected, this.closeConnection);
         }
     }
 

--- a/src/modules/signer/signer.service.ts
+++ b/src/modules/signer/signer.service.ts
@@ -1,6 +1,5 @@
 import { BigNumber, providers, utils, Wallet, ethers, Signer } from "ethers";
 import base64url from "base64url";
-import { EventEmitter } from "events";
 import WalletConnectProvider from "@walletconnect/ethereum-provider";
 import { Methods } from "@ew-did-registry/did";
 import { ERROR_MESSAGES } from "../../errors/ErrorMessages";
@@ -21,6 +20,8 @@ export class SignerService {
     private _chainName: string;
 
     private _servicesInitializers: ServiceInitializer[] = [];
+
+    private _walletEventListeners: { event: ProviderEvent; cb: any }[] = [];
 
     constructor(private _signer: Required<Signer>, private _providerType: ProviderType) {}
 
@@ -53,13 +54,16 @@ export class SignerService {
         this._servicesInitializers.push(initializer);
     }
 
-    on(event: ProviderEvent, cb) {
-        const provider = this._signer.provider;
-        if (provider instanceof EventEmitter) {
-            provider.on(event, cb);
-        } else if (provider instanceof WalletConnectProvider) {
-            provider.on(event, cb);
+    async emit(e: ProviderEvent) {
+        for await (const { event, cb } of this._walletEventListeners) {
+            if (event === e) {
+                await cb();
+            }
         }
+    }
+
+    on(event: ProviderEvent, cb) {
+        this._walletEventListeners.push({ event, cb });
     }
 
     /**
@@ -71,10 +75,13 @@ export class SignerService {
             await this.closeConnection();
             await this.init();
         };
-        this.on(ProviderEvent.AccountChanged, accChangedHandler);
-        this.on(ProviderEvent.NetworkChanged, accChangedHandler);
-        this.on(ProviderEvent.Disconnected, this.closeConnection());
-        this.on(ProviderEvent.SessionUpdate, accChangedHandler);
+        if (this._providerType === ProviderType.MetaMask) {
+            this.on(ProviderEvent.AccountChanged, accChangedHandler);
+            this.on(ProviderEvent.NetworkChanged, accChangedHandler);
+        } else if (this._providerType === ProviderType.WalletConnect) {
+            this.on(ProviderEvent.SessionUpdate, accChangedHandler);
+            this.on(ProviderEvent.Disconnected, this.closeConnection());
+        }
     }
 
     get signer() {

--- a/src/modules/signer/signer.types.ts
+++ b/src/modules/signer/signer.types.ts
@@ -8,8 +8,14 @@ export enum ProviderType {
 }
 
 export enum ProviderEvent {
+    /**
+     * Metamask events https://docs.metamask.io/guide/ethereum-provider.html#events
+     */
     AccountChanged = "accountsChanged",
     NetworkChanged = "networkChanged",
+    /**
+     * WalletConnect events https://docs.walletconnect.com/1.0/client-api#register-event-subscription
+     */
     Disconnected = "disconnect",
     SessionUpdate = "session_update",
 }

--- a/src/modules/signer/signer.types.ts
+++ b/src/modules/signer/signer.types.ts
@@ -8,9 +8,9 @@ export enum ProviderType {
 }
 
 export enum ProviderEvent {
-    AccountChanged = "accountChanged",
+    AccountChanged = "accountsChanged",
     NetworkChanged = "networkChanged",
-    Disconnected = "disconnected",
+    Disconnected = "disconnect",
     SessionUpdate = "session_update",
 }
 

--- a/src/modules/signer/walletConnectMetamask.ts
+++ b/src/modules/signer/walletConnectMetamask.ts
@@ -11,7 +11,7 @@ export const fromWalletConnectMetamask = async (bridge: string, infuraId?: strin
     const walletProvider = createWalletConnectProvider(bridge, infuraId);
     await walletProvider.enable();
     const provider = new providers.Web3Provider(walletProvider);
-    const signerService = new SignerService(provider.getSigner(), ProviderType.MetaMask);
+    const signerService = new SignerService(provider.getSigner(), ProviderType.WalletConnect);
     walletProvider.on(ProviderEvent.Disconnected, signerService.emit(ProviderEvent.Disconnected));
     walletProvider.on(ProviderEvent.SessionUpdate, signerService.emit(ProviderEvent.SessionUpdate));
     await signerService.init();

--- a/src/modules/signer/walletConnectMetamask.ts
+++ b/src/modules/signer/walletConnectMetamask.ts
@@ -2,7 +2,7 @@ import Web3Provider from "@walletconnect/ethereum-provider";
 import WalletConnect from "@walletconnect/client";
 import QRCodeModal from "@walletconnect/qrcode-modal";
 import { ICreateSessionOptions } from "@walletconnect/types";
-import { ProviderType } from "./signer.types";
+import { ProviderEvent, ProviderType } from "./signer.types";
 import { SignerService } from "./signer.service";
 import { providers } from "ethers";
 import { chainConfigs } from "../../config/chain.config";
@@ -12,6 +12,8 @@ export const fromWalletConnectMetamask = async (bridge: string, infuraId?: strin
     await walletProvider.enable();
     const provider = new providers.Web3Provider(walletProvider);
     const signerService = new SignerService(provider.getSigner(), ProviderType.MetaMask);
+    walletProvider.on(ProviderEvent.Disconnected, signerService.emit(ProviderEvent.Disconnected));
+    walletProvider.on(ProviderEvent.SessionUpdate, signerService.emit(ProviderEvent.SessionUpdate));
     await signerService.init();
     return signerService;
 };

--- a/src/modules/signer/walletConnectMetamask.ts
+++ b/src/modules/signer/walletConnectMetamask.ts
@@ -12,7 +12,7 @@ export const fromWalletConnectMetamask = async (bridge: string, infuraId?: strin
     await walletProvider.enable();
     const provider = new providers.Web3Provider(walletProvider);
     const signerService = new SignerService(provider.getSigner(), ProviderType.WalletConnect);
-    walletProvider.on(ProviderEvent.Disconnected, signerService.emit(ProviderEvent.Disconnected));
+    walletProvider.on(ProviderEvent.Disconnected, () => signerService.emit(ProviderEvent.Disconnected));
     walletProvider.on(ProviderEvent.SessionUpdate, signerService.emit(ProviderEvent.SessionUpdate));
     await signerService.init();
     return signerService;

--- a/src/modules/signer/walletConnectMetamask.ts
+++ b/src/modules/signer/walletConnectMetamask.ts
@@ -13,7 +13,7 @@ export const fromWalletConnectMetamask = async (bridge: string, infuraId?: strin
     const provider = new providers.Web3Provider(walletProvider);
     const signerService = new SignerService(provider.getSigner(), ProviderType.WalletConnect);
     walletProvider.on(ProviderEvent.Disconnected, () => signerService.emit(ProviderEvent.Disconnected));
-    walletProvider.on(ProviderEvent.SessionUpdate, signerService.emit(ProviderEvent.SessionUpdate));
+    walletProvider.on(ProviderEvent.SessionUpdate, () => signerService.emit(ProviderEvent.SessionUpdate));
     await signerService.init();
     return signerService;
 };


### PR DESCRIPTION
I can see two ways to enable signer service to listen on events emitted by `Metamask` or `WalletConnect` wallets:
- Underlying signer can extend `ethers.Signer` with `on` method
- wallet provider notifies signer service

I have chosen second way, because extending signer requires to implement `ethers.Signer` instead of getting it from `Web3Provider` wrapper from `ethers`. May be there is a better design