### PR TITLE
feat(claims.service): ICL-159 add hasOnChainRole utility

### DIFF
--- a/docs/api/classes/modules_claims_claims_service.ClaimsService.md
+++ b/docs/api/classes/modules_claims_claims_service.ClaimsService.md
@@ -22,6 +22,7 @@
 - [getClaimsBySubject](modules_claims_claims_service.ClaimsService.md#getclaimsbysubject)
 - [getClaimsBySubjects](modules_claims_claims_service.ClaimsService.md#getclaimsbysubjects)
 - [getUserClaims](modules_claims_claims_service.ClaimsService.md#getuserclaims)
+- [hasOnChainRole](modules_claims_claims_service.ClaimsService.md#hasonchainrole)
 - [init](modules_claims_claims_service.ClaimsService.md#init)
 - [issueClaim](modules_claims_claims_service.ClaimsService.md#issueclaim)
 - [issueClaimRequest](modules_claims_claims_service.ClaimsService.md#issueclaimrequest)
@@ -277,6 +278,29 @@ getUserClaims
 #### Returns
 
 `Promise`<`IServiceEndpoint` & [`ClaimData`](../interfaces/modules_didRegistry_did_types.ClaimData.md)[]\>
+
+___
+
+### hasOnChainRole
+
+▸ **hasOnChainRole**(`did`, `role`, `version`): `Promise`<`boolean`\>
+
+A utility function to check the blockchain directly if a DID has a role
+TODO: fail if the DID chain ID doesn't match the configured signer network connect
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `did` | `string` | The ethr DID to check |
+| `role` | `string` | The role to check (the full namespace) |
+| `version` | `number` | The version to check |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+true if DID has role at the version. false if not.
 
 ___
 

--- a/docs/api/classes/modules_signer_signer_service.SignerService.md
+++ b/docs/api/classes/modules_signer_signer_service.SignerService.md
@@ -21,6 +21,7 @@
 ### Methods
 
 - [balance](modules_signer_signer_service.SignerService.md#balance)
+- [call](modules_signer_signer_service.SignerService.md#call)
 - [closeConnection](modules_signer_signer_service.SignerService.md#closeconnection)
 - [connect](modules_signer_signer_service.SignerService.md#connect)
 - [emit](modules_signer_signer_service.SignerService.md#emit)
@@ -125,6 +126,27 @@ ___
 #### Returns
 
 `Promise`<`BigNumber`\>
+
+___
+
+### call
+
+▸ **call**(`__namedParameters`): `Promise`<`string`\>
+
+Makes a (readonly) call to a smart contract
+https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-call
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | `TransactionRequest` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+The result of the call
 
 ___
 

--- a/e2e/claims.service.e2e.ts
+++ b/e2e/claims.service.e2e.ts
@@ -196,14 +196,15 @@ describe("Enrollment claim tests", () => {
     test("enrollment by issuer of type DID", async () => {
         const requester = rootOwner;
         const issuer = staticIssuer;
+        const role = `${roleName1}.${root}`;
+        expect(await claimsService.hasOnChainRole(rootOwnerDID, role, version)).toBe(false);
         await enrolAndIssue(requester, issuer, {
             subjectDID: rootOwnerDID,
             claimType: `${roleName1}.${root}`,
         });
 
-        return expect(
-            claimManager.hasRole(addressOf(rootOwnerDID), namehash(`${roleName1}.${root}`), version),
-        ).resolves.toBe(true);
+        expect(claimManager.hasRole(addressOf(rootOwnerDID), namehash(role), version)).resolves.toBe(true);
+        expect(await claimsService.hasOnChainRole(rootOwnerDID, role, version)).toBe(true);
     });
 
     test("asset enrollment by issuer of type DID", async () => {

--- a/src/modules/claims/claims.service.ts
+++ b/src/modules/claims/claims.service.ts
@@ -63,6 +63,27 @@ export class ClaimsService {
         this._claimManager = chainConfigs()[chainId].claimManagerAddress;
     }
 
+    /**
+     * A utility function to check the blockchain directly if a DID has a role
+     * TODO: fail if the DID chain ID doesn't match the configured signer network connect
+     * @param did The ethr DID to check
+     * @param role The role to check (the full namespace)
+     * @param version The version to check
+     * @returns true if DID has role at the version. false if not.
+     */
+    async hasOnChainRole(did: string, role: string, version: number): Promise<boolean> {
+        const data = this._claimManagerInterface.encodeFunctionData("hasRole", [
+            addressOf(did),
+            namehash(role),
+            version,
+        ]);
+        const result = await this._signerService.call({
+            to: this._claimManager,
+            data,
+        });
+        return Boolean(Number.parseInt(result));
+    }
+
     async getClaimsBySubjects(subjects: string[]) {
         return this._cacheClient.getClaimsBySubjects(subjects);
     }

--- a/src/modules/claims/claims.service.ts
+++ b/src/modules/claims/claims.service.ts
@@ -77,11 +77,15 @@ export class ClaimsService {
             namehash(role),
             version,
         ]);
+        // Expect result to be either:
+        // '0x0000000000000000000000000000000000000000000000000000000000000000'
+        // '0x0000000000000000000000000000000000000000000000000000000000000001'
         const result = await this._signerService.call({
             to: this._claimManager,
             data,
         });
-        return Boolean(Number.parseInt(result));
+        const intFromHexString = Number.parseInt(result);
+        return Boolean(intFromHexString);
     }
 
     async getClaimsBySubjects(subjects: string[]) {

--- a/src/modules/signer/signer.service.ts
+++ b/src/modules/signer/signer.service.ts
@@ -124,6 +124,19 @@ export class SignerService {
         return receipt;
     }
 
+    /**
+     * Makes a (readonly) call to a smart contract
+     * https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-call
+     * @param params.to adddress of contract
+     * @param params.data call data
+     * @returns The result of the call
+     */
+    async call({ to, data }: providers.TransactionRequest): Promise<string> {
+        const tx = { to, from: this.address, data };
+        const result = await this._signer.call(tx);
+        return result;
+    }
+
     async signMessage(message: Uint8Array) {
         return this.signer.signMessage(message);
     }


### PR DESCRIPTION
Implements: https://energyweb.atlassian.net/browse/ICL-159 

@dawidgil should be useful for staking page to check whether or not can try to stake and for seeing whether or not they need to "add" an approve on-chain role to the ClaimManager smart contract (https://energyweb.atlassian.net/browse/SWTCH-1259)