### PR TITLE
fix(assets): rollback asset event type to uppercase

### DIFF
--- a/docs/api/enums/modules_assets_assets_types.AssetHistoryEventType.md
+++ b/docs/api/enums/modules_assets_assets_types.AssetHistoryEventType.md
@@ -16,28 +16,28 @@
 
 ### ASSET\_CREATED
 
-• **ASSET\_CREATED** = `"asset-created"`
+• **ASSET\_CREATED** = `"ASSET_CREATED"`
 
 ___
 
 ### ASSET\_OFFERED
 
-• **ASSET\_OFFERED** = `"asset-offered"`
+• **ASSET\_OFFERED** = `"ASSET_OFFERED"`
 
 ___
 
 ### ASSET\_OFFER\_CANCELED
 
-• **ASSET\_OFFER\_CANCELED** = `"asset-offer-canceled"`
+• **ASSET\_OFFER\_CANCELED** = `"ASSET_OFFER_CANCELED"`
 
 ___
 
 ### ASSET\_OFFER\_REJECTED
 
-• **ASSET\_OFFER\_REJECTED** = `"asset-offer-rejected"`
+• **ASSET\_OFFER\_REJECTED** = `"ASSET_OFFER_REJECTED"`
 
 ___
 
 ### ASSET\_TRANSFERRED
 
-• **ASSET\_TRANSFERRED** = `"asset-transfered"`
+• **ASSET\_TRANSFERRED** = `"ASSET_TRANSFERRED"`

--- a/src/modules/assets/assets.types.ts
+++ b/src/modules/assets/assets.types.ts
@@ -19,9 +19,9 @@ export interface AssetHistory {
 }
 
 export enum AssetHistoryEventType {
-    ASSET_CREATED = "asset-created",
-    ASSET_OFFERED = "asset-offered",
-    ASSET_OFFER_CANCELED = "asset-offer-canceled",
-    ASSET_TRANSFERRED = "asset-transfered",
-    ASSET_OFFER_REJECTED = "asset-offer-rejected",
+    ASSET_CREATED = "ASSET_CREATED",
+    ASSET_OFFERED = "ASSET_OFFERED",
+    ASSET_OFFER_CANCELED = "ASSET_OFFER_CANCELED",
+    ASSET_TRANSFERRED = "ASSET_TRANSFERRED",
+    ASSET_OFFER_REJECTED = "ASSET_OFFER_REJECTED",
 }


### PR DESCRIPTION
asset event type is in use in too many places to perform migration easily