### PR TITLE
feat(claims): rename fields to requestorFields for better readibility

### DIFF
--- a/docs/api/classes/modules_cacheClient_cacheClient_service.CacheClient.md
+++ b/docs/api/classes/modules_cacheClient_cacheClient_service.CacheClient.md
@@ -660,17 +660,19 @@ ___
 
 ▸ **handleError**(`error`): `Promise`<`unknown`\>
 
-**`description`** At the time hanldes only authentication errors. Schedules failed requests and starts authentication
+**`description`** Interceptor of authentication errors. Queues failed requests and starts authentication process.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `error` | `AxiosError`<`any`\> |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `error` | `AxiosError`<`any`\> | Intercepted response from failed request |
 
 #### Returns
 
 `Promise`<`unknown`\>
+
+Promise, which resolves with result of resending of failed request
 
 ___
 
@@ -722,6 +724,9 @@ ___
 ### login
 
 ▸ **login**(): `Promise`<`void`\>
+
+Verifies current session and establishes new one if needed
+https://energyweb.atlassian.net/wiki/spaces/MYEN/pages/2303295607/ICL-+ICS+Auth+Process
 
 #### Returns
 

--- a/docs/api/classes/modules_claims_claims_service.ClaimsService.md
+++ b/docs/api/classes/modules_claims_claims_service.ClaimsService.md
@@ -54,6 +54,8 @@
 
 **`description`** allows subject to request for credential
 
+**`deprecated`** fields - use requestorFields instead
+
 #### Parameters
 
 | Name | Type |
@@ -62,8 +64,9 @@
 | `__namedParameters.claim` | `Object` |
 | `__namedParameters.claim.claimType` | `string` |
 | `__namedParameters.claim.claimTypeVersion` | `number` |
-| `__namedParameters.claim.fields` | { `key`: `string` ; `value`: `string` \| `number`  }[] |
+| `__namedParameters.claim.fields?` | { `key`: `string` ; `value`: `string` \| `number`  }[] |
 | `__namedParameters.claim.issuerFields?` | { `key`: `string` ; `value`: `string` \| `number`  }[] |
+| `__namedParameters.claim.requestorFields?` | { `key`: `string` ; `value`: `string` \| `number`  }[] |
 | `__namedParameters.registrationTypes?` | [`RegistrationTypes`](../enums/modules_claims_claims_types.RegistrationTypes.md)[] |
 | `__namedParameters.subject?` | `string` |
 

--- a/e2e/claims.service.e2e.ts
+++ b/e2e/claims.service.e2e.ts
@@ -153,7 +153,7 @@ describe("Enrollment claim tests", () => {
         await signerService.connect(requestSigner, ProviderType.PrivateKey);
         const requesterDID = signerService.did;
         await claimsService.createClaimRequest({
-            claim: { claimType, claimTypeVersion: version, fields: [{ key: "temperature", value: 36 }] },
+            claim: { claimType, claimTypeVersion: version, requestorFields: [{ key: "temperature", value: 36 }] },
             registrationTypes,
             subject: subjectDID,
         });
@@ -318,7 +318,7 @@ describe("Enrollment claim tests", () => {
 
         const registrationTypes = [RegistrationTypes.OnChain, RegistrationTypes.OffChain];
         await claimsService.createClaimRequest({
-            claim: { claimType: `${roleName1}.${root}`, claimTypeVersion: 1, fields: [] },
+            claim: { claimType: `${roleName1}.${root}`, claimTypeVersion: 1, requestorFields: [] },
             registrationTypes,
         });
         const [, message] = mockRequestClaim.mock.calls.pop();

--- a/e2e/staking.pool.e2e.ts
+++ b/e2e/staking.pool.e2e.ts
@@ -119,7 +119,7 @@ describe("StakingPool tests", () => {
         await signerService.connect(patron, ProviderType.PrivateKey);
         mockGetRoleDefinition.mockReturnValueOnce(data);
         await claimsService.createClaimRequest({
-            claim: { claimType: `${patronRole}.${root}`, claimTypeVersion: 1, fields: [] },
+            claim: { claimType: `${patronRole}.${root}`, claimTypeVersion: 1, requestorFields: [] },
             registrationTypes,
         });
 

--- a/e2e/staking.service.e2e.ts
+++ b/e2e/staking.service.e2e.ts
@@ -112,7 +112,7 @@ describe("Staking service tests", () => {
         await signerService.connect(patron, ProviderType.PrivateKey);
         mockGetRoleDefinition.mockReturnValueOnce(data);
         await claimsService.createClaimRequest({
-            claim: { claimType: `${patronRole}.${root}`, claimTypeVersion: 1, fields: [] },
+            claim: { claimType: `${patronRole}.${root}`, claimTypeVersion: 1, requestorFields: [] },
             registrationTypes,
         });
 

--- a/src/modules/cacheClient/cacheClient.service.ts
+++ b/src/modules/cacheClient/cacheClient.service.ts
@@ -77,9 +77,9 @@ export class CacheClient implements ICacheClient {
 
     /**
      * @description Interceptor of authentication errors. Queues failed requests and starts authentication process.
-     * 
+     *
      * @param error Intercepted response from failed request
-     * 
+     *
      * @returns Promise, which resolves with result of resending of failed request
      */
     async handleError(error: AxiosError) {
@@ -110,7 +110,7 @@ export class CacheClient implements ICacheClient {
     }
 
     /**
-     * Verifies current session and establishes new one if needed 
+     * Verifies current session and establishes new one if needed
      * https://energyweb.atlassian.net/wiki/spaces/MYEN/pages/2303295607/ICL-+ICS+Auth+Process
      */
     async login() {

--- a/src/modules/claims/claims.service.ts
+++ b/src/modules/claims/claims.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { utils, Wallet } from "ethers";
 import jsonwebtoken from "jsonwebtoken";
 import { v4 } from "uuid";
@@ -139,6 +140,7 @@ export class ClaimsService {
     }
     /**
      * @description allows subject to request for credential
+     * @deprecated fields - use requestorFields instead
      */
 
     async createClaimRequest({
@@ -149,14 +151,18 @@ export class ClaimsService {
         claim: {
             claimType: string;
             claimTypeVersion: number;
-            fields: { key: string; value: string | number }[];
+            fields?: { key: string; value: string | number }[];
+            requestorFields?: { key: string; value: string | number }[];
             issuerFields?: { key: string; value: string | number }[];
         };
         subject?: string;
         registrationTypes?: RegistrationTypes[];
     }) {
         const { claimType: role, claimTypeVersion: version } = claim;
-        const token = await this._didRegistry.createPublicClaim({ data: claim, subject });
+        const { fields, ...strippedClaim } = claim;
+        const data = { ...strippedClaim, requestorFields: claim.requestorFields || fields || [] };
+
+        const token = await this._didRegistry.createPublicClaim({ data, subject });
 
         await this.verifyEnrolmentPrerequisites({ subject, role });
 


### PR DESCRIPTION
fields renamed to requestorFields. They will coexist for now for backward compatibility.