### PR TITLE
bug/ICL-171 onchain claim is not registered by WalletConnect

### DIFF
--- a/e2e/claims.service.e2e.ts
+++ b/e2e/claims.service.e2e.ts
@@ -121,6 +121,7 @@ describe("Enrollment claim tests", () => {
         await setupENS(await rootOwner.getAddress());
         let connectToCacheServer;
         ({ signerService, connectToCacheServer } = await initWithPrivateKeySigner(rootOwner.privateKey, rpcUrl));
+        await signerService.publicKeyAndIdentityToken();
         const chainId = signerService.chainId;
         claimManager = new ClaimManager__factory(rootOwner).attach(chainConfigs()[chainId].claimManagerAddress);
         let connectToDidRegistry;

--- a/e2e/staking.pool.e2e.ts
+++ b/e2e/staking.pool.e2e.ts
@@ -78,6 +78,7 @@ describe("StakingPool tests", () => {
         await setupStakingPoolFactory();
         let connectToCacheServer;
         ({ connectToCacheServer, signerService } = await initWithPrivateKeySigner(rootOwner.privateKey, rpcUrl));
+        await signerService.publicKeyAndIdentityToken();
         let connectToDidRegistry;
         ({ domainsService, stakingService, connectToDidRegistry } = await connectToCacheServer());
         const { claimsService } = await connectToDidRegistry();

--- a/e2e/staking.service.e2e.ts
+++ b/e2e/staking.service.e2e.ts
@@ -71,6 +71,7 @@ describe("Staking service tests", () => {
         await setupStakingPoolFactory();
         let connectToCacheServer;
         ({ connectToCacheServer, signerService } = await initWithPrivateKeySigner(rootOwner.privateKey, rpcUrl));
+        await signerService.publicKeyAndIdentityToken();
         let connectToDidRegistry;
         ({ domainsService, stakingService, connectToDidRegistry } = await connectToCacheServer());
         const { claimsService } = await connectToDidRegistry();

--- a/src/errors/ErrorMessages.ts
+++ b/src/errors/ErrorMessages.ts
@@ -2,7 +2,7 @@ export enum ERROR_MESSAGES {
     UNKNOWN_PROVIDER = "Unknown provider type",
     ENS_TYPE_NOT_SUPPORTED = "ENS type not supported",
     WALLET_PROVIDER_NOT_SUPPORTED = "Wallet provider must be a supported value",
-    PUBLIC_KEY_NOT_RECOVERED = "Public key not recovered",
+    NON_ETH_SIGN_SIGNATURE = "Signature is not eth_sign verifiable",
     ORG_WITH_APPS = "You are not able to remove organization with registered apps",
     ORG_WITH_ROLES = "You are not able to remove organization with registered roles",
     APP_WITH_ROLES = "You are not able to remove application with registered roles",

--- a/src/errors/ErrorMessages.ts
+++ b/src/errors/ErrorMessages.ts
@@ -20,4 +20,5 @@ export enum ERROR_MESSAGES {
     JWT_ALGORITHM_NOT_SUPPORTED = "Jwt algorithm not supported",
     CLAIM_WAS_NOT_ISSUED = "Claim was not issued",
     ENS_OWNER_NOT_VALID_ADDRESS = "Provided owner is not a valid address. Owner of ENS domain must be an address",
+    IS_ETH_SIGNER_NOT_SET = "Can not determine if signer is conformant with eth_sign specification",
 }

--- a/src/modules/claims/claims.service.ts
+++ b/src/modules/claims/claims.service.ts
@@ -494,7 +494,7 @@ export class ClaimsService {
         );
         const agreement_type_hash = id("Agreement(address subject,bytes32 role,uint256 version)");
 
-        const chainId = await this._signerService.chainId;
+        const chainId = this._signerService.chainId;
         const domainSeparator = keccak256(
             defaultAbiCoder.encode(
                 ["bytes32", "bytes32", "bytes32", "uint256", "address"],

--- a/src/modules/signer/signer.service.ts
+++ b/src/modules/signer/signer.service.ts
@@ -48,7 +48,7 @@ export class SignerService {
         } else if (this._signer instanceof Wallet) {
             this._account = this._address;
         }
-        // browser is responsible for clearing of isEthSigner on logout
+        // web app is responsible for clearing of isEthSigner on logout
         if (executionEnvironment() === ExecutionEnvironment.BROWSER) {
             const isEthSigner = localStorage.getItem(IS_ETH_SIGNER);
             if (isEthSigner) {

--- a/src/modules/signer/signer.service.ts
+++ b/src/modules/signer/signer.service.ts
@@ -143,9 +143,9 @@ export class SignerService {
 
     /**
      * @description Tries to create `eth_sign` conformant signature (https://eth.wiki/json-rpc/API#eth_sign)
-     * Signing method is determined based on previous signing
+     * Whether or not to hash the message prior to signature is determined by signature performed during login
      *
-     * @param message Message should have binary representation to avoid confusion of text with hexadecimal binary data
+     * @param message The message to be signed. The message should have binary representation to avoid confusion of text with hexadecimal binary data
      */
     async signMessage(message: Uint8Array) {
         const messageHash = this._isEthSigner ? message : arrayify(hashMessage(message));

--- a/src/modules/signer/signer.types.ts
+++ b/src/modules/signer/signer.types.ts
@@ -32,3 +32,4 @@ export type AccountInfo = {
 };
 
 export const PUBLIC_KEY = "PublicKey";
+export const IS_ETH_SIGNER = "isEthSigner";

--- a/src/modules/signer/walletConnectMetamask.ts
+++ b/src/modules/signer/walletConnectMetamask.ts
@@ -24,7 +24,6 @@ export const createWalletConnectProvider = (bridge: string, infuraId?: string) =
         rpc,
         connector: new Connector({ bridge, qrcodeModal: QRCodeModal }),
         infuraId,
-        chainId: 73799,
     });
     return walletConnectProvider;
 };

--- a/src/modules/signer/walletConnectMetamask.ts
+++ b/src/modules/signer/walletConnectMetamask.ts
@@ -24,6 +24,7 @@ export const createWalletConnectProvider = (bridge: string, infuraId?: string) =
         rpc,
         connector: new Connector({ bridge, qrcodeModal: QRCodeModal }),
         infuraId,
+        chainId: 73799,
     });
     return walletConnectProvider;
 };


### PR DESCRIPTION
https://energyweb.atlassian.net/browse/ICL-171

- [x] SignerService.signMessage` will try to create signatures compatible with eth_sign specification (https://eth.wiki/json-rpc/API#eth_sign). This is required to verify claim signer and verifier by Claim Manager smart contract. Message to sign will be prefixed depending on exact signer. Signer type will be determined on login to cache server