### PR TITLE
fix: change return type for `getAllowedRolesByIssuer`

### DIFF
--- a/docs/api/classes/CacheClient.md
+++ b/docs/api/classes/CacheClient.md
@@ -132,7 +132,7 @@ ___
 
 ### getAllowedRolesByIssuer
 
-▸ **getAllowedRolesByIssuer**(`did`): `Promise`<`string`[]\>
+▸ **getAllowedRolesByIssuer**(`did`): `Promise`<[`IRole`](../interfaces/IRole.md)[]\>
 
 #### Parameters
 
@@ -142,7 +142,7 @@ ___
 
 #### Returns
 
-`Promise`<`string`[]\>
+`Promise`<[`IRole`](../interfaces/IRole.md)[]\>
 
 ___
 

--- a/docs/api/classes/DomainsService.md
+++ b/docs/api/classes/DomainsService.md
@@ -294,7 +294,7 @@ ___
 
 ### getAllowedRolesByIssuer
 
-▸ **getAllowedRolesByIssuer**(`did`): `Promise`<`string`[]\>
+▸ **getAllowedRolesByIssuer**(`did`): `Promise`<[`IRole`](../interfaces/IRole.md)[]\>
 
 getAllowedRolesByIssuer
 
@@ -308,7 +308,7 @@ getAllowedRolesByIssuer
 
 #### Returns
 
-`Promise`<`string`[]\>
+`Promise`<[`IRole`](../interfaces/IRole.md)[]\>
 
 array of roles that the DID can issue
 

--- a/src/modules/cacheClient/cacheClient.service.ts
+++ b/src/modules/cacheClient/cacheClient.service.ts
@@ -283,7 +283,7 @@ export class CacheClient implements ICacheClient {
   }
 
   async getAllowedRolesByIssuer(did: string) {
-    const { data } = await this.httpClient.get<string[]>(`/claim/issuer/roles/allowed/${did}`);
+    const { data } = await this.httpClient.get<IRole[]>(`/claim/issuer/roles/allowed/${did}`);
     return data;
   }
 


### PR DESCRIPTION
`getAllowedRolesByIssuer` is currently returning the role definition.