### PR TITLE
feat(did): update did document params validation

### DIFF
--- a/docs/api/enums/ERROR_MESSAGES.md
+++ b/docs/api/enums/ERROR_MESSAGES.md
@@ -5,6 +5,7 @@
 ### Enumeration members
 
 - [APP\_WITH\_ROLES](ERROR_MESSAGES.md#app_with_roles)
+- [CAN\_NOT\_UPDATE\_DOCUMENT\_PROPERTIES\_INVALID\_OR\_MISSING](ERROR_MESSAGES.md#can_not_update_document_properties_invalid_or_missing)
 - [CAN\_NOT\_UPDATE\_NOT\_CONTROLLED\_DOCUMENT](ERROR_MESSAGES.md#can_not_update_not_controlled_document)
 - [CLAIM\_TYPE\_REQUIRED\_FOR\_ON\_CHAIN\_REGISTRATION](ERROR_MESSAGES.md#claim_type_required_for_on_chain_registration)
 - [CLAIM\_WAS\_NOT\_ISSUED](ERROR_MESSAGES.md#claim_was_not_issued)
@@ -35,6 +36,12 @@
 ### APP\_WITH\_ROLES
 
 • **APP\_WITH\_ROLES** = `"You are not able to remove application with registered roles"`
+
+___
+
+### CAN\_NOT\_UPDATE\_DOCUMENT\_PROPERTIES\_INVALID\_OR\_MISSING
+
+• **CAN\_NOT\_UPDATE\_DOCUMENT\_PROPERTIES\_INVALID\_OR\_MISSING** = `"Cannot update document. Properties invalid or missing: "`
 
 ___
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iam-client-lib",
-  "version": "4.2.1-alpha.3",
+  "version": "4.2.1-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iam-client-lib",
-      "version": "4.2.1-alpha.3",
+      "version": "4.2.1-alpha.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@energyweb/ekc": "^0.6.5",
@@ -38,6 +38,7 @@
         "lodash.difference": "^4.5.0",
         "nats.ws": "^1.7.1",
         "qs": "^6.9.4",
+        "ts-interface-checker": "^1.0.2",
         "tslib": "^2.0.3",
         "uuid": "^7.0.3"
       },
@@ -26379,6 +26380,11 @@
         "typescript": ">=3.7.0"
       }
     },
+    "node_modules/ts-interface-checker": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-1.0.2.tgz",
+      "integrity": "sha512-4IKKvhZRXhvtYF/mtu+OCfBqJKV6LczUq4kQYcpT+iSB7++R9+giWnp2ecwWMIcnG16btVOkXFnoxLSYMN1Q1g=="
+    },
     "node_modules/ts-jest": {
       "version": "26.5.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
@@ -47532,6 +47538,11 @@
       "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
       "dev": true,
       "requires": {}
+    },
+    "ts-interface-checker": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-1.0.2.tgz",
+      "integrity": "sha512-4IKKvhZRXhvtYF/mtu+OCfBqJKV6LczUq4kQYcpT+iSB7++R9+giWnp2ecwWMIcnG16btVOkXFnoxLSYMN1Q1g=="
     },
     "ts-jest": {
       "version": "26.5.6",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "lodash.difference": "^4.5.0",
     "nats.ws": "^1.7.1",
     "qs": "^6.9.4",
+    "ts-interface-checker": "^1.0.2",
     "tslib": "^2.0.3",
     "uuid": "^7.0.3"
   },

--- a/src/errors/ErrorMessages.ts
+++ b/src/errors/ErrorMessages.ts
@@ -11,6 +11,7 @@ export enum ERROR_MESSAGES {
   ROLE_PREREQUISITES_NOT_MET = "Enrolment subject doesn't have required roles",
   ROLE_NOT_EXISTS = 'Role you want to enroll to does not exists',
   CAN_NOT_UPDATE_NOT_CONTROLLED_DOCUMENT = 'Can not update not controlled document',
+  CAN_NOT_UPDATE_DOCUMENT_PROPERTIES_INVALID_OR_MISSING = 'Cannot update document. Properties invalid or missing: ',
   ONCHAIN_ROLE_VERSION_NOT_SPECIFIED = 'On-chain role version not specified',
   WITHDRAWAL_WAS_NOT_REQUESTED = 'Stake withdrawal was not requested',
   STAKE_WAS_NOT_PUT = 'Stake was not put',

--- a/src/modules/didRegistry/didRegistry.validation.ts
+++ b/src/modules/didRegistry/didRegistry.validation.ts
@@ -1,0 +1,52 @@
+import {
+  DIDAttribute,
+  Encoding,
+  PubKeyType,
+} from '@ew-did-registry/did-resolver-interface';
+import { KeyType } from '@ew-did-registry/keys';
+import { createCheckers, iface, enumtype } from 'ts-interface-checker';
+
+const IS_REQ_STRING = 'string';
+export const { UpdateServicePoint, UpdateDelegate, UpdatePublicKey } =
+  createCheckers({
+    UpdateServicePoint: iface([], {
+      did: IS_REQ_STRING,
+      didAttribute: enumtype({ ServicePoint: DIDAttribute.ServicePoint }),
+      data: iface([], {
+        type: enumtype({ ServicePoint: DIDAttribute.ServicePoint }),
+        value: iface([], {
+          id: IS_REQ_STRING,
+          hash: IS_REQ_STRING,
+          hashAlg: IS_REQ_STRING,
+        }),
+      }),
+    }),
+
+    UpdateDelegate: iface([], {
+      did: IS_REQ_STRING,
+      didAttribute: enumtype({ Authenticate: DIDAttribute.Authenticate }),
+      data: iface([], {
+        type: enumtype(PubKeyType),
+        value: iface([], {
+          id: IS_REQ_STRING,
+          hash: IS_REQ_STRING,
+          hashAlg: IS_REQ_STRING,
+        }),
+        delegate: IS_REQ_STRING,
+      }),
+    }),
+
+    UpdatePublicKey: iface([], {
+      did: IS_REQ_STRING,
+      didAttribute: enumtype({ PublicKey: DIDAttribute.PublicKey }),
+      data: iface([], {
+        type: enumtype(PubKeyType),
+        algo: enumtype(KeyType),
+        encoding: enumtype(Encoding),
+        value: iface([], {
+          publicKey: IS_REQ_STRING,
+          tag: IS_REQ_STRING,
+        }),
+      }),
+    }),
+  });


### PR DESCRIPTION
### Description

checking params on updateSignedDidPublicKey, updateSignedDidDelegate functions
checking params on updateDocument conditionally depending on didAttribute value
in case of validation issues - throws Error with the list of invalid or missing properties

### Contributor checklist

- [ v ] Breaking changes - no BC only thing is no more false-positive DID updates. In case there was one, there will be error thrown instead
- [ v ] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [ v ] Tests - regression tests were used to verify the code
- [ v ] Migration guide - not apply
- [ v ] Configuration correctness - not apply