### PR TITLE
fix: avoid refreshing undefined token

### DIFF
--- a/docs/api/classes/modules_assets.AssetsService.md
+++ b/docs/api/classes/modules_assets.AssetsService.md
@@ -14,6 +14,7 @@
 - [cancelAssetOffer](modules_assets.AssetsService.md#cancelassetoffer)
 - [getAssetById](modules_assets.AssetsService.md#getassetbyid)
 - [getAssetHistory](modules_assets.AssetsService.md#getassethistory)
+- [getAssetOwner](modules_assets.AssetsService.md#getassetowner)
 - [getOfferedAssets](modules_assets.AssetsService.md#getofferedassets)
 - [getOwnedAssets](modules_assets.AssetsService.md#getownedassets)
 - [getPreviouslyOwnedAssets](modules_assets.AssetsService.md#getpreviouslyownedassets)
@@ -86,7 +87,7 @@ ___
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `id` | `Object` | Asset Id |
+| `id` | `Object` | Asset decentralized identifier |
 | `id.id` | `string` | - |
 
 #### Returns
@@ -119,6 +120,24 @@ ___
 `Promise`<[`AssetHistory`](../interfaces/modules_assets.AssetHistory.md)[]\>
 
 Asset[] || []
+
+___
+
+### getAssetOwner
+
+▸ **getAssetOwner**(`id`): `Promise`<`string`\>
+
+Returns owner of the given asset
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` | asset decentralized identifier |
+
+#### Returns
+
+`Promise`<`string`\>
 
 ___
 
@@ -223,7 +242,7 @@ ___
 
 `Promise`<`string`\>
 
-Asset DID
+Asset address
 
 ___
 


### PR DESCRIPTION
### Description

Avoid refreshing tokens when `refresh token` is undefined

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
