### PR TITLE
fix: throw an error when a did document update failed

### DIFF
--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -31,4 +31,5 @@ export enum ERROR_MESSAGES {
   ONCHAIN_ROLE_SUBJECT_AGREEMENT_NOT_SPECIFIED = 'On-chain role subject agreement not specified',
   REVOKE_CLAIM_MISSING_PARAMETERS = 'Revoke claim missing parameters. Required one of: claimId or claim',
   REVOKE_CLAIM_NOT_FOUND = 'Could not find claim to revoke',
+  DID_DOCUMENT_NOT_UPDATED = 'DID Document was not updated',
 }

--- a/src/modules/claims/claims.service.ts
+++ b/src/modules/claims/claims.service.ts
@@ -719,11 +719,15 @@ export class ClaimsService {
           hashAlg: 'SHA256',
         },
       };
-      await this._didRegistry.updateDocument({
+      const isDocUpdated = await this._didRegistry.updateDocument({
         didAttribute: DIDAttribute.ServicePoint,
         data,
         did: sub,
       });
+
+      if (!isDocUpdated) {
+        throw new Error(ERROR_MESSAGES.DID_DOCUMENT_NOT_UPDATED);
+      }
     }
     return url;
   }

--- a/src/modules/did-registry/did-registry.service.ts
+++ b/src/modules/did-registry/did-registry.service.ts
@@ -1,4 +1,4 @@
-import { Wallet, providers } from 'ethers';
+import { Wallet, providers, BigNumber } from 'ethers';
 import { CID } from 'multiformats/cid';
 import { KeyType } from '@ew-did-registry/keys';
 import { JWT } from '@ew-did-registry/jwt';
@@ -341,7 +341,7 @@ export class DidRegistry {
 
     const update = await didDocument.update(didAttribute, updateData, validity);
 
-    return Boolean(update);
+    return update._hex !== BigNumber.from(0)._hex;
   }
 
   /**


### PR DESCRIPTION
### Description

Fix DID document update checking. Throw an error when a DID document update failed during off-chain claim publishing.

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
