### PR TITLE
feat: adding more details to error log line when http request fails

### DIFF
--- a/src/modules/cache-client/cache-client.service.ts
+++ b/src/modules/cache-client/cache-client.service.ts
@@ -602,6 +602,8 @@ export class CacheClient implements ICacheClient {
         ...error.config.headers,
         Authorization: error.config.headers?.Authorization ? '***' : undefined,
       },
+      status: error.response?.status,
+      statusText: error.response?.statusText,
       responseHeaders: error.response?.headers,
     };
 

--- a/src/modules/cache-client/cache-client.service.ts
+++ b/src/modules/cache-client/cache-client.service.ts
@@ -594,7 +594,20 @@ export class CacheClient implements ICacheClient {
       return false;
     }
 
-    getLogger().debug(`[CACHE CLIENT] axios error: ${error.message}`);
+    const errorDetails = {
+      message: error.message,
+      url: error.config.url,
+      method: error.config.method,
+      requestHeaders: {
+        ...error.config.headers,
+        Authorization: error.config.headers?.Authorization ? '***' : undefined,
+      },
+      responseHeaders: error.response?.headers,
+    };
+
+    getLogger().debug(
+      `[CACHE CLIENT] axios error: ${JSON.stringify(errorDetails)}`
+    );
     const { config, response } = error;
 
     if (!response) {


### PR DESCRIPTION
This PR adds more details to `[CACHE CLIENT] axios error:` type error log lines. This includes:
* url
* method
* response status code
* response status text
* response headers
* request headers with `Authorization` header value masked
