### PR TITLE
fix(exp): do not use dflt validity period to calculate timestamp if n…

### DIFF
--- a/docs/api/modules/modules_claims.md
+++ b/docs/api/modules/modules_claims.md
@@ -133,7 +133,7 @@ ___
 
 ### readyToBeRegisteredOnchain
 
-▸ **readyToBeRegisteredOnchain**(`claim`): claim is Required<Pick<Claim, "claimType" \| "claimTypeVersion" \| "subject" \| "onChainProof" \| "acceptedBy" \| "subjectAgreement"\> & Object\>
+▸ **readyToBeRegisteredOnchain**(`claim`): claim is Required<Pick<Claim, "claimType" \| "claimTypeVersion" \| "subject" \| "onChainProof" \| "acceptedBy"\> & Object\>
 
 #### Parameters
 
@@ -143,4 +143,4 @@ ___
 
 #### Returns
 
-claim is Required<Pick<Claim, "claimType" \| "claimTypeVersion" \| "subject" \| "onChainProof" \| "acceptedBy" \| "subjectAgreement"\> & Object\>
+claim is Required<Pick<Claim, "claimType" \| "claimTypeVersion" \| "subject" \| "onChainProof" \| "acceptedBy"\> & Object\>

--- a/e2e/claims.service.e2e.ts
+++ b/e2e/claims.service.e2e.ts
@@ -461,8 +461,6 @@ describe('Сlaim tests', () => {
         expect(onChainProof).toHaveLength(132);
 
         if (expirationTimestamp || roleDefinitionValidityPeriod) {
-          console.log(expirationTimestamp, 'EXP TIMESTAMP');
-          console.log(roleDefinitionValidityPeriod, 'VALIDITY PERIOD');
           const filter = claimManager.filters.RoleRegistered();
           const logs = await claimManager.queryFilter(filter);
 

--- a/e2e/claims.service.e2e.ts
+++ b/e2e/claims.service.e2e.ts
@@ -457,12 +457,12 @@ describe('Сlaim tests', () => {
       expect(requester).toEqual(requesterDID);
       expect(claimIssuer).toEqual([issuerDID]);
 
-      if (
-        registrationTypes.includes(RegistrationTypes.OnChain)
-      ) {
+      if (registrationTypes.includes(RegistrationTypes.OnChain)) {
         expect(onChainProof).toHaveLength(132);
 
         if (expirationTimestamp || roleDefinitionValidityPeriod) {
+          console.log(expirationTimestamp, 'EXP TIMESTAMP');
+          console.log(roleDefinitionValidityPeriod, 'VALIDITY PERIOD');
           const filter = claimManager.filters.RoleRegistered();
           const logs = await claimManager.queryFilter(filter);
 
@@ -482,12 +482,6 @@ describe('Сlaim tests', () => {
             ) {
               expirationTimestamp &&
                 expect(args.expiry.toNumber()).toEqual(expirationTimestamp);
-
-              !expirationTimestamp &&
-                roleDefinitionValidityPeriod &&
-                expect(args.expiry.toNumber()).toBeLessThanOrEqual(
-                  Date.now() + roleDefinitionValidityPeriod
-                );
             }
           });
         }


### PR DESCRIPTION

### Description

- Remove logic to calculate timestamp from default validity period if no expiration timestamp is sent AND role has a default validity period

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
