### PR TITLE
fix(issue claim): allow boolean as valid field

### DIFF
--- a/src/modules/verifiable-credentials/types/verifiable-credentials.types.ts
+++ b/src/modules/verifiable-credentials/types/verifiable-credentials.types.ts
@@ -33,7 +33,7 @@ export const validateRoleCredentialSubject = (
   subject: RoleCredentialSubjectParams
 ) => {
   const invalidField = subject.issuerFields?.find(
-    (field) => !['string', 'number'].includes(typeof field.value)
+    (field) => !['string', 'number', 'boolean'].includes(typeof field.value)
   );
   if (invalidField) {
     throw new InterfaceNotSatisfied(


### PR DESCRIPTION
### Description

For bug: https://energyweb.atlassian.net/browse/SWTCH-1409
issuerFields can be a boolean value, which is not a valid type in this field check. 
const issuerFields = [{key: 'Checkboolean ', value: true}]

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
