### PR TITLE
fix: bump ew-credentials to 2.2.1-alpha.296.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "iam-client-lib",
-  "version": "6.2.1-alpha.2",
+  "version": "7.0.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iam-client-lib",
-      "version": "6.2.1-alpha.2",
+      "version": "7.0.0-alpha.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@energyweb/credential-governance": "^2.2.1-alpha.295.0",
+        "@energyweb/credential-governance": "^2.2.1-alpha.296.0",
         "@energyweb/ekc": "^0.6.7",
-        "@energyweb/onchain-claims": "^2.2.1-alpha.295.0",
+        "@energyweb/onchain-claims": "^2.2.1-alpha.296.0",
         "@energyweb/staking-pool": "^1.0.0-rc.14",
-        "@energyweb/vc-verification": "^2.2.1-alpha.295.0",
+        "@energyweb/vc-verification": "^2.2.1-alpha.296.0",
         "@ensdomains/ens": "^0.6.2",
         "@ew-did-registry/claims": "0.7.1-alpha.816.0",
         "@ew-did-registry/credentials-interface": "0.7.1-alpha.816.0",
@@ -1941,9 +1941,9 @@
       }
     },
     "node_modules/@energyweb/credential-governance": {
-      "version": "2.2.1-alpha.295.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.295.0.tgz",
-      "integrity": "sha512-4jhiEVoOkbQLZ2D6Wl5L6SCEurz8BX14Ljy48a7wj6O66/0ozAOpkwRX2HD/nrZ/GUTOkR1Mus8GuKivwMjXaw==",
+      "version": "2.2.1-alpha.296.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.296.0.tgz",
+      "integrity": "sha512-AS4/XV+OWDNxLfCfNxfssxMADCOgEF4dP26PpxE8MjaSnN126CyICNTwgVSy9u1k/fmam1vgBXjGwTeRjSLZqQ==",
       "dependencies": {
         "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
         "@ew-did-registry/did": "^0.7.1-alpha.795.0",
@@ -1972,11 +1972,11 @@
       }
     },
     "node_modules/@energyweb/onchain-claims": {
-      "version": "2.2.1-alpha.295.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.295.0.tgz",
-      "integrity": "sha512-ivTRGVniMuOjiVSjsMhmJNJJeafrNqnRjVqDCcAOhRTg6pIOLxHWTdST93YX+KnhKzruWTeha0gHAXsCsQG9oQ==",
+      "version": "2.2.1-alpha.296.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.296.0.tgz",
+      "integrity": "sha512-ZFv4qo8HqZ6gXL0ERgfrtC13NDY/HkFuE0As5Aj7O4gbszeLDGwIGZEtiRj/W0a5WVGWXVHqgbXiFnFjMMN+/A==",
       "dependencies": {
-        "@energyweb/credential-governance": "2.2.1-alpha.295.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.296.0",
         "@ew-did-registry/did": "^0.7.1-alpha.795.0",
         "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
         "@poanet/solidity-flattener": "^3.0.7",
@@ -2014,12 +2014,12 @@
       "integrity": "sha512-+cNYvQwTKFMbKVqvVHGzcZbW+z1/pKTyQIYDDC3PaX5L0NAOshI/ZXAsrZRqp/6xEdWsm9f6u549ZLvCEUgNLw=="
     },
     "node_modules/@energyweb/vc-verification": {
-      "version": "2.2.1-alpha.295.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.295.0.tgz",
-      "integrity": "sha512-WLmFEYTCraGfT9jjAalLT+NBXHUAkCCvXmWFCTxGMmw9zQSNS9vVFOv8NOEfYEzm91Tf0EG1QNcaUZQXAH6TKg==",
+      "version": "2.2.1-alpha.296.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.296.0.tgz",
+      "integrity": "sha512-OhpODzLhOc+37bjeE+rejOcNPutkIvu+hyJV9jJL4JYjSLNJo4EaFsrhnd2FiY796SI1L1aIpjyY5oBC1081UA==",
       "dependencies": {
-        "@energyweb/credential-governance": "2.2.1-alpha.295.0",
-        "@energyweb/onchain-claims": "2.2.1-alpha.295.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.296.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.296.0",
         "@ew-did-registry/claims": "^0.7.1-alpha.795.0",
         "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
         "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
@@ -36689,9 +36689,9 @@
       }
     },
     "@energyweb/credential-governance": {
-      "version": "2.2.1-alpha.295.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.295.0.tgz",
-      "integrity": "sha512-4jhiEVoOkbQLZ2D6Wl5L6SCEurz8BX14Ljy48a7wj6O66/0ozAOpkwRX2HD/nrZ/GUTOkR1Mus8GuKivwMjXaw==",
+      "version": "2.2.1-alpha.296.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.296.0.tgz",
+      "integrity": "sha512-AS4/XV+OWDNxLfCfNxfssxMADCOgEF4dP26PpxE8MjaSnN126CyICNTwgVSy9u1k/fmam1vgBXjGwTeRjSLZqQ==",
       "requires": {
         "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
         "@ew-did-registry/did": "^0.7.1-alpha.795.0",
@@ -36715,11 +36715,11 @@
       "requires": {}
     },
     "@energyweb/onchain-claims": {
-      "version": "2.2.1-alpha.295.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.295.0.tgz",
-      "integrity": "sha512-ivTRGVniMuOjiVSjsMhmJNJJeafrNqnRjVqDCcAOhRTg6pIOLxHWTdST93YX+KnhKzruWTeha0gHAXsCsQG9oQ==",
+      "version": "2.2.1-alpha.296.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.296.0.tgz",
+      "integrity": "sha512-ZFv4qo8HqZ6gXL0ERgfrtC13NDY/HkFuE0As5Aj7O4gbszeLDGwIGZEtiRj/W0a5WVGWXVHqgbXiFnFjMMN+/A==",
       "requires": {
-        "@energyweb/credential-governance": "2.2.1-alpha.295.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.296.0",
         "@ew-did-registry/did": "^0.7.1-alpha.795.0",
         "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
         "@poanet/solidity-flattener": "^3.0.7",
@@ -36746,12 +36746,12 @@
       "integrity": "sha512-+cNYvQwTKFMbKVqvVHGzcZbW+z1/pKTyQIYDDC3PaX5L0NAOshI/ZXAsrZRqp/6xEdWsm9f6u549ZLvCEUgNLw=="
     },
     "@energyweb/vc-verification": {
-      "version": "2.2.1-alpha.295.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.295.0.tgz",
-      "integrity": "sha512-WLmFEYTCraGfT9jjAalLT+NBXHUAkCCvXmWFCTxGMmw9zQSNS9vVFOv8NOEfYEzm91Tf0EG1QNcaUZQXAH6TKg==",
+      "version": "2.2.1-alpha.296.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.296.0.tgz",
+      "integrity": "sha512-OhpODzLhOc+37bjeE+rejOcNPutkIvu+hyJV9jJL4JYjSLNJo4EaFsrhnd2FiY796SI1L1aIpjyY5oBC1081UA==",
       "requires": {
-        "@energyweb/credential-governance": "2.2.1-alpha.295.0",
-        "@energyweb/onchain-claims": "2.2.1-alpha.295.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.296.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.296.0",
         "@ew-did-registry/claims": "^0.7.1-alpha.795.0",
         "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
         "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",

--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
     "npm": ">= 6.0.0"
   },
   "dependencies": {
-    "@energyweb/credential-governance": "^2.2.1-alpha.295.0",
+    "@energyweb/credential-governance": "^2.2.1-alpha.296.0",
     "@energyweb/ekc": "^0.6.7",
-    "@energyweb/onchain-claims": "^2.2.1-alpha.295.0",
+    "@energyweb/onchain-claims": "^2.2.1-alpha.296.0",
     "@energyweb/staking-pool": "^1.0.0-rc.14",
-    "@energyweb/vc-verification": "^2.2.1-alpha.295.0",
+    "@energyweb/vc-verification": "^2.2.1-alpha.296.0",
     "@ensdomains/ens": "^0.6.2",
     "@ew-did-registry/claims": "0.7.1-alpha.816.0",
     "@ew-did-registry/credentials-interface": "0.7.1-alpha.816.0",


### PR DESCRIPTION
### Description

- Bumps ew-credentials version. If a user has a request to approve a role that she does not have the correct approval role for, the error will specify the role that she does not have. 
- Old Error: No authorative credential found for issuer
- New Error: No authorative credential found for issuer for role "installer.role..."

@jrhender and @JGiter It sounded from the [story](https://energyweb.atlassian.net/jira/software/projects/SWTCH/boards/54?assignee=608057a2e3b59800688dbc2a&selectedIssue=SWTCH-1455) that you wanted to add more info to this error. Should ICL catch the error from verifyIssuer, and if the error contains this text return it with more descriptive error message such as 'No authorative credential found for issuer for role "installer.role...". You must obtain and publish this role before approving this request.' 
Or should we just throw this new error? 

Update - we will just return this error and in the future address the root issue that SSI hub returns role approval requests that a user is not authorized to approve due to not having/publishing role

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
