### PR TITLE
fix: add type attribute in assethistory

### DIFF
--- a/docs/api/interfaces/modules_assets.AssetHistory.md
+++ b/docs/api/interfaces/modules_assets.AssetHistory.md
@@ -12,6 +12,7 @@
 - [id](modules_assets.AssetHistory.md#id)
 - [relatedTo](modules_assets.AssetHistory.md#relatedto)
 - [timestamp](modules_assets.AssetHistory.md#timestamp)
+- [type](modules_assets.AssetHistory.md#type)
 
 ## Properties
 
@@ -48,3 +49,9 @@ ___
 ### timestamp
 
 • **timestamp**: `string`
+
+___
+
+### type
+
+• **type**: [`AssetHistoryEventType`](../enums/modules_assets.AssetHistoryEventType.md)

--- a/src/modules/assets/assets.types.ts
+++ b/src/modules/assets/assets.types.ts
@@ -17,6 +17,7 @@ export interface AssetHistory {
   at: number;
   timestamp: string;
   assetId?: string;
+  type: AssetHistoryEventType;
 }
 
 export enum AssetHistoryEventType {


### PR DESCRIPTION
### Description

Add `type` property missing in `AssetHistory`, this would make it consistent with the `AssetHistory` entity in `SSI-Hub` - https://github.com/energywebfoundation/ssi-hub/blob/9e653eeb14f1b0ce8d63a1c50a90eea548294ca7/src/modules/assets/assets.entity.ts#L76
<!-- PUT YOUR TASK DESCRIPTION HERE -->

### Contributor checklist

- [ ] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [ ] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [ ] Tests - add new or updated existed test for changes you made.
- [ ] Migration guide - add migration guide for every breaking change.
- [ ] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
