### PR TITLE
chore: update ew-creds packages to 2.2.1-alpha.312

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "iam-client-lib",
-  "version": "7.0.0-alpha.4",
+  "version": "7.0.1-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iam-client-lib",
-      "version": "7.0.0-alpha.4",
+      "version": "7.0.1-alpha.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@energyweb/credential-governance": "2.2.1-alpha.310.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.312.0",
         "@energyweb/ekc": "^0.6.7",
-        "@energyweb/onchain-claims": "2.2.1-alpha.310.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.312.0",
         "@energyweb/staking-pool": "^1.0.0-rc.14",
-        "@energyweb/vc-verification": "2.2.1-alpha.310.0",
+        "@energyweb/vc-verification": "2.2.1-alpha.312.0",
         "@ensdomains/ens": "^0.6.2",
         "@ew-did-registry/claims": "0.8.1-alpha.996.0",
         "@ew-did-registry/credentials-interface": "0.8.1-alpha.996.0",
@@ -1941,14 +1941,30 @@
       }
     },
     "node_modules/@energyweb/credential-governance": {
-      "version": "2.2.1-alpha.310.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.310.0.tgz",
-      "integrity": "sha512-utIW/ezLXt8oinyhkD7YeAmNVVd7gzWUTUhDrZOmsAJgyV6+PemYtJzI5Qbib1hFx2QrFtsBDzlpG5RGOm47rQ==",
+      "version": "2.2.1-alpha.312.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.312.0.tgz",
+      "integrity": "sha512-bnB/1jn2/nUIZ7ZAopo+mN4wPI19IPiI8nhIKpsRk6/UtMQtsw2/sqyWkBz1v3SWJd2QF+PA4NYMEFZwX7Bdtg==",
       "dependencies": {
-        "@ew-did-registry/credentials-interface": "0.8.1-alpha.996.0",
-        "@ew-did-registry/did": "0.8.1-alpha.996.0",
-        "ethers": "^5.7.0"
+        "@ew-did-registry/credentials-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2"
       }
+    },
+    "node_modules/@energyweb/credential-governance/node_modules/@ew-did-registry/credentials-interface": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-ZRQhKJXBe+FP8q2aICmdEtz1fUe25HgrHDWc3+BsneNx6vGpmhGNpCotVkLBdMppdeN+yCl2izqSSX1K6J5AoQ==",
+      "dependencies": {
+        "@sphereon/pex": "1.1.3",
+        "@types/lodash": "^4.14.181",
+        "joi": "^17.6.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@energyweb/credential-governance/node_modules/@ew-did-registry/did": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-bupVwCH9EYM/qpbZGMzacFNslA0Ng5aFrmsXLVmuJMJRHOx4zbsA+Y3XaGmPF9v7d9Gyr58gLREBeACvksqkpg=="
     },
     "node_modules/@energyweb/ekc": {
       "version": "0.6.7",
@@ -1972,16 +1988,60 @@
       }
     },
     "node_modules/@energyweb/onchain-claims": {
-      "version": "2.2.1-alpha.310.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.310.0.tgz",
-      "integrity": "sha512-fn1pp8QMtZjYWYSS4w+Ctfy1qJrYGD3nzT4KDKKHt2F5tPTUi/PSeIOCrLxKrLfjJCStPs2U0iPi9a30k48GsQ==",
+      "version": "2.2.1-alpha.312.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.312.0.tgz",
+      "integrity": "sha512-P0aRLeKPDIzHqhrxK0LOrGNdD0pefvotNlwmK0gqX5hvtCySqpfwuGhk3SUNBq/xGqanuOrsf0s4kmZ08bDYaw==",
       "dependencies": {
-        "@energyweb/credential-governance": "2.2.1-alpha.310.0",
-        "@ew-did-registry/did": "0.8.1-alpha.996.0",
-        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.996.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.312.0",
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.1015.0",
         "@poanet/solidity-flattener": "^3.0.7",
-        "ethers": "^5.7.0"
+        "ethers": "^5.7.2"
       }
+    },
+    "node_modules/@energyweb/onchain-claims/node_modules/@ew-did-registry/did": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-bupVwCH9EYM/qpbZGMzacFNslA0Ng5aFrmsXLVmuJMJRHOx4zbsA+Y3XaGmPF9v7d9Gyr58gLREBeACvksqkpg=="
+    },
+    "node_modules/@energyweb/onchain-claims/node_modules/@ew-did-registry/did-ethr-resolver": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-jNkWgR12bRh8LJ6OUOOnsfw+OSTJFG7N6BMwwV4Fw576W3NDid3zzZYD2HI2LXDUS2D3BMiPaLy6gdq0nNzazA==",
+      "dependencies": {
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@energyweb/onchain-claims/node_modules/@ew-did-registry/did-resolver-interface": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-GHjzVhI1MacVkpNd0/tFVX7wGyvSpBGW4i2FLswpteEGd6tAW/q8h28EyutmgnIZ3YBn7Bz5Xxi8a3Ans63t6Q==",
+      "dependencies": {
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@energyweb/onchain-claims/node_modules/@ew-did-registry/keys": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-sKkkcnj66znSWayMr5O4U+t59jCwVg5iJVe3w6EzKLuraJCA0stS2tYh35/CbOtVJAMf/JBiEEIKn5j2RAtXgw==",
+      "dependencies": {
+        "bn.js": "5.2.0",
+        "ec-key": "0.0.4",
+        "eciesjs": "^0.3.4",
+        "elliptic": "^6.5.2",
+        "ethers": "^5.7.2",
+        "key-encoder": "^2.0.3"
+      }
+    },
+    "node_modules/@energyweb/onchain-claims/node_modules/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/@energyweb/prettier-config": {
       "version": "0.0.1",
@@ -2014,22 +2074,192 @@
       "integrity": "sha512-+cNYvQwTKFMbKVqvVHGzcZbW+z1/pKTyQIYDDC3PaX5L0NAOshI/ZXAsrZRqp/6xEdWsm9f6u549ZLvCEUgNLw=="
     },
     "node_modules/@energyweb/vc-verification": {
-      "version": "2.2.1-alpha.310.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.310.0.tgz",
-      "integrity": "sha512-mAn2QHODJsZRZGXaRmVJKSZQbMyf6RB/IgOpGZAP2nblsQKKDvzQ7nK9NZ46NRTQsnXXpnyohy8l5Awhj+DAVg==",
+      "version": "2.2.1-alpha.312.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.312.0.tgz",
+      "integrity": "sha512-VpJWfEu0RKnVj6tdtM2uo1TU/bfoAlozV2Pt6IU7AVoJG3WUBaf93AHA8A6plTZ2CEHJ/qudE0aXHjbg2Himyg==",
       "dependencies": {
-        "@energyweb/credential-governance": "2.2.1-alpha.310.0",
-        "@energyweb/onchain-claims": "2.2.1-alpha.310.0",
-        "@ew-did-registry/claims": "0.8.1-alpha.996.0",
-        "@ew-did-registry/credentials-interface": "0.8.1-alpha.996.0",
-        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.996.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.312.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.312.0",
+        "@ew-did-registry/claims": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/credentials-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.1015.0",
         "@ew-did-registry/did-ipfs-store": "0.7.1-alpha.816.0",
-        "@ew-did-registry/did-store-interface": "0.8.1-alpha.996.0",
-        "@ew-did-registry/revocation": "0.8.1-alpha.996.0",
-        "ethers": "^5.7.0",
+        "@ew-did-registry/did-store-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/revocation": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2",
         "ipfs-http-client": "^43.0.0",
         "lodash": "^4.17.21"
       }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/claims": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/claims/-/claims-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-/4fDEsoOOU9oCSi/zsuBOWOJnQokdWuE3ntNeGsCNJcLsawxYcHCSaYjN6BqSaCOvsd+cR9OIDG5gc5ZqbVclA==",
+      "dependencies": {
+        "@ew-did-registry/credentials-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-document": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-ipfs-store": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-store-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/jwt": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+        "@types/sjcl": "1.0.28",
+        "base64url": "^3.0.1",
+        "eciesjs": "^0.3.4",
+        "ethers": "^5.7.2",
+        "sjcl": "npm:sjcl-complete@1.0.0"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/claims/node_modules/@ew-did-registry/did-ipfs-store": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ipfs-store/-/did-ipfs-store-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-xKubaflwDF/2bUwoJgbhDRcb0lRHk44iEjP00Ub6OQ22NwbKPsHFwX/VJiZqOxi+FQu+LISgiE6ISrbbHa54wg==",
+      "dependencies": {
+        "@ew-did-registry/did-store-interface": "0.8.1-alpha.1015.0",
+        "@web-std/fetch": "^4.1.0",
+        "@web-std/file": "^3.0.2",
+        "@web-std/form-data": "^3.0.2",
+        "axios": "^0.27.2"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/credentials-interface": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-ZRQhKJXBe+FP8q2aICmdEtz1fUe25HgrHDWc3+BsneNx6vGpmhGNpCotVkLBdMppdeN+yCl2izqSSX1K6J5AoQ==",
+      "dependencies": {
+        "@sphereon/pex": "1.1.3",
+        "@types/lodash": "^4.14.181",
+        "joi": "^17.6.0",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/did": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-bupVwCH9EYM/qpbZGMzacFNslA0Ng5aFrmsXLVmuJMJRHOx4zbsA+Y3XaGmPF9v7d9Gyr58gLREBeACvksqkpg=="
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/did-document": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-SZVxaA52LcdSDVIAHDmQ4YXjHGWISmnXu1iGwkydTg98g/Sc7QDTGSYN5hwMTwJ3pqOsWFqgZLuX2CyDix9JTQ==",
+      "dependencies": {
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/did-ethr-resolver": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-jNkWgR12bRh8LJ6OUOOnsfw+OSTJFG7N6BMwwV4Fw576W3NDid3zzZYD2HI2LXDUS2D3BMiPaLy6gdq0nNzazA==",
+      "dependencies": {
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/did-resolver-interface": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-GHjzVhI1MacVkpNd0/tFVX7wGyvSpBGW4i2FLswpteEGd6tAW/q8h28EyutmgnIZ3YBn7Bz5Xxi8a3Ans63t6Q==",
+      "dependencies": {
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/did-store-interface": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-store-interface/-/did-store-interface-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-oiyXUR16D9FHaC3OBx9QOWJkUTsdvE5mIwyeJWUyP+aYkDxJQpTE4rGKSu1XOm9zu/S8KnFR7T9mLAQupHlmJg=="
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/jwt": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/jwt/-/jwt-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-XnPeBDxlD0wiLSzXpoLGf5oDgjB5gUb/j3uxOKgAq3dQqVWoVOLaamf85JYmiTYmvhfIDq/8nG14UVEaXjgKaw==",
+      "dependencies": {
+        "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+        "base64url": "^3.0.1",
+        "ec-key": "0.0.4",
+        "ethereumjs-util": "^7.0.5",
+        "ethers": "^5.7.2",
+        "jsonwebtoken": "^8.5.1",
+        "promise.allsettled": "^1.0.2"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/keys": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-sKkkcnj66znSWayMr5O4U+t59jCwVg5iJVe3w6EzKLuraJCA0stS2tYh35/CbOtVJAMf/JBiEEIKn5j2RAtXgw==",
+      "dependencies": {
+        "bn.js": "5.2.0",
+        "ec-key": "0.0.4",
+        "eciesjs": "^0.3.4",
+        "elliptic": "^6.5.2",
+        "ethers": "^5.7.2",
+        "key-encoder": "^2.0.3"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/revocation": {
+      "version": "0.8.1-alpha.1015.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/revocation/-/revocation-0.8.1-alpha.1015.0.tgz",
+      "integrity": "sha512-993J/X5Tmbg+DUu+yowwwXDzmRlm6Z0FQi5WLZytrIPaS1zxs87tVa+PHBBFsXng4kYqRXJ4Lc90j8jzqHxNKg==",
+      "dependencies": {
+        "@ew-did-registry/credentials-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-ethr-resolver": "0.6.0",
+        "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+        "axios": "^0.27.2",
+        "didkit-wasm-node": "^0.1.6",
+        "ethers": "^5.7.2"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/did-ethr-resolver": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.6.0.tgz",
+      "integrity": "sha512-cwByi6Ic43vm+l7TyBY4auN5tg45HjAdHGitWn+ZH25qZRBajcaizCjPekai+kAU4DNJVis/XqsmYP1NtIagRA==",
+      "dependencies": {
+        "@ew-did-registry/did": "0.6.0",
+        "@ew-did-registry/did-resolver-interface": "0.6.0",
+        "@ew-did-registry/keys": "0.6.0",
+        "ethers": "^5.4.6"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/did-ethr-resolver/node_modules/@ew-did-registry/did": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.6.0.tgz",
+      "integrity": "sha512-GOvIDdu5giS3I8E+mhOMzHXNu1mq1VXAT3NPchOHslVcI1LVLgtgXIfudoAMleL/XjVhSb18JoPKboGGGzRG8A=="
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/did-ethr-resolver/node_modules/@ew-did-registry/did-resolver-interface": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.6.0.tgz",
+      "integrity": "sha512-UKmoCW51Y98ddT0mlfCUfEWnM7v1IzFKFFXi2aNvhd6NvmCE91KoaUuEivaYoG4LtT/xIJus18n/EWsTQXZRyA==",
+      "dependencies": {
+        "@ew-did-registry/did": "0.6.0",
+        "ethers": "^5.4.6"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/@ew-did-registry/revocation/node_modules/@ew-did-registry/did-ethr-resolver/node_modules/@ew-did-registry/keys": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.6.0.tgz",
+      "integrity": "sha512-mHO6ao2FnVlazOsbNwdViEtafbMMG0iShxOqqr6dgSRuBwz9lV0I70PYfj6UlHIvYP6T0KwlIbXMx8oZYw/XbQ==",
+      "dependencies": {
+        "bn.js": "5.2.0",
+        "eciesjs": "^0.3.4",
+        "elliptic": "^6.5.2",
+        "ethers": "^5.4.6"
+      }
+    },
+    "node_modules/@energyweb/vc-verification/node_modules/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/@ensdomains/ens": {
       "version": "0.6.2",
@@ -2557,9 +2787,9 @@
       }
     },
     "node_modules/@ethersproject/providers": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.1.tgz",
-      "integrity": "sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
       "funding": [
         {
           "type": "individual",
@@ -11411,9 +11641,9 @@
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/ethers": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.1.tgz",
-      "integrity": "sha512-5krze4dRLITX7FpU8J4WscXqADiKmyeNlylmmDLbS95DaZpBhDe2YSwRQwKXWNyXcox7a3gBgm/MkGXV1O1S/Q==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "funding": [
         {
           "type": "individual",
@@ -11443,7 +11673,7 @@
         "@ethersproject/networks": "5.7.1",
         "@ethersproject/pbkdf2": "5.7.0",
         "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.1",
+        "@ethersproject/providers": "5.7.2",
         "@ethersproject/random": "5.7.0",
         "@ethersproject/rlp": "5.7.0",
         "@ethersproject/sha2": "5.7.0",
@@ -36702,13 +36932,31 @@
       }
     },
     "@energyweb/credential-governance": {
-      "version": "2.2.1-alpha.310.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.310.0.tgz",
-      "integrity": "sha512-utIW/ezLXt8oinyhkD7YeAmNVVd7gzWUTUhDrZOmsAJgyV6+PemYtJzI5Qbib1hFx2QrFtsBDzlpG5RGOm47rQ==",
+      "version": "2.2.1-alpha.312.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/credential-governance/-/credential-governance-2.2.1-alpha.312.0.tgz",
+      "integrity": "sha512-bnB/1jn2/nUIZ7ZAopo+mN4wPI19IPiI8nhIKpsRk6/UtMQtsw2/sqyWkBz1v3SWJd2QF+PA4NYMEFZwX7Bdtg==",
       "requires": {
-        "@ew-did-registry/credentials-interface": "0.8.1-alpha.996.0",
-        "@ew-did-registry/did": "0.8.1-alpha.996.0",
-        "ethers": "^5.7.0"
+        "@ew-did-registry/credentials-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2"
+      },
+      "dependencies": {
+        "@ew-did-registry/credentials-interface": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-ZRQhKJXBe+FP8q2aICmdEtz1fUe25HgrHDWc3+BsneNx6vGpmhGNpCotVkLBdMppdeN+yCl2izqSSX1K6J5AoQ==",
+          "requires": {
+            "@sphereon/pex": "1.1.3",
+            "@types/lodash": "^4.14.181",
+            "joi": "^17.6.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@ew-did-registry/did": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-bupVwCH9EYM/qpbZGMzacFNslA0Ng5aFrmsXLVmuJMJRHOx4zbsA+Y3XaGmPF9v7d9Gyr58gLREBeACvksqkpg=="
+        }
       }
     },
     "@energyweb/ekc": {
@@ -36728,15 +36976,61 @@
       "requires": {}
     },
     "@energyweb/onchain-claims": {
-      "version": "2.2.1-alpha.310.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.310.0.tgz",
-      "integrity": "sha512-fn1pp8QMtZjYWYSS4w+Ctfy1qJrYGD3nzT4KDKKHt2F5tPTUi/PSeIOCrLxKrLfjJCStPs2U0iPi9a30k48GsQ==",
+      "version": "2.2.1-alpha.312.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/onchain-claims/-/onchain-claims-2.2.1-alpha.312.0.tgz",
+      "integrity": "sha512-P0aRLeKPDIzHqhrxK0LOrGNdD0pefvotNlwmK0gqX5hvtCySqpfwuGhk3SUNBq/xGqanuOrsf0s4kmZ08bDYaw==",
       "requires": {
-        "@energyweb/credential-governance": "2.2.1-alpha.310.0",
-        "@ew-did-registry/did": "0.8.1-alpha.996.0",
-        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.996.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.312.0",
+        "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.1015.0",
         "@poanet/solidity-flattener": "^3.0.7",
-        "ethers": "^5.7.0"
+        "ethers": "^5.7.2"
+      },
+      "dependencies": {
+        "@ew-did-registry/did": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-bupVwCH9EYM/qpbZGMzacFNslA0Ng5aFrmsXLVmuJMJRHOx4zbsA+Y3XaGmPF9v7d9Gyr58gLREBeACvksqkpg=="
+        },
+        "@ew-did-registry/did-ethr-resolver": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-jNkWgR12bRh8LJ6OUOOnsfw+OSTJFG7N6BMwwV4Fw576W3NDid3zzZYD2HI2LXDUS2D3BMiPaLy6gdq0nNzazA==",
+          "requires": {
+            "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+            "ethers": "^5.7.2"
+          }
+        },
+        "@ew-did-registry/did-resolver-interface": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-GHjzVhI1MacVkpNd0/tFVX7wGyvSpBGW4i2FLswpteEGd6tAW/q8h28EyutmgnIZ3YBn7Bz5Xxi8a3Ans63t6Q==",
+          "requires": {
+            "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+            "ethers": "^5.7.2"
+          }
+        },
+        "@ew-did-registry/keys": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-sKkkcnj66znSWayMr5O4U+t59jCwVg5iJVe3w6EzKLuraJCA0stS2tYh35/CbOtVJAMf/JBiEEIKn5j2RAtXgw==",
+          "requires": {
+            "bn.js": "5.2.0",
+            "ec-key": "0.0.4",
+            "eciesjs": "^0.3.4",
+            "elliptic": "^6.5.2",
+            "ethers": "^5.7.2",
+            "key-encoder": "^2.0.3"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        }
       }
     },
     "@energyweb/prettier-config": {
@@ -36759,21 +37053,199 @@
       "integrity": "sha512-+cNYvQwTKFMbKVqvVHGzcZbW+z1/pKTyQIYDDC3PaX5L0NAOshI/ZXAsrZRqp/6xEdWsm9f6u549ZLvCEUgNLw=="
     },
     "@energyweb/vc-verification": {
-      "version": "2.2.1-alpha.310.0",
-      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.310.0.tgz",
-      "integrity": "sha512-mAn2QHODJsZRZGXaRmVJKSZQbMyf6RB/IgOpGZAP2nblsQKKDvzQ7nK9NZ46NRTQsnXXpnyohy8l5Awhj+DAVg==",
+      "version": "2.2.1-alpha.312.0",
+      "resolved": "https://registry.npmjs.org/@energyweb/vc-verification/-/vc-verification-2.2.1-alpha.312.0.tgz",
+      "integrity": "sha512-VpJWfEu0RKnVj6tdtM2uo1TU/bfoAlozV2Pt6IU7AVoJG3WUBaf93AHA8A6plTZ2CEHJ/qudE0aXHjbg2Himyg==",
       "requires": {
-        "@energyweb/credential-governance": "2.2.1-alpha.310.0",
-        "@energyweb/onchain-claims": "2.2.1-alpha.310.0",
-        "@ew-did-registry/claims": "0.8.1-alpha.996.0",
-        "@ew-did-registry/credentials-interface": "0.8.1-alpha.996.0",
-        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.996.0",
+        "@energyweb/credential-governance": "2.2.1-alpha.312.0",
+        "@energyweb/onchain-claims": "2.2.1-alpha.312.0",
+        "@ew-did-registry/claims": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/credentials-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.1015.0",
         "@ew-did-registry/did-ipfs-store": "0.7.1-alpha.816.0",
-        "@ew-did-registry/did-store-interface": "0.8.1-alpha.996.0",
-        "@ew-did-registry/revocation": "0.8.1-alpha.996.0",
-        "ethers": "^5.7.0",
+        "@ew-did-registry/did-store-interface": "0.8.1-alpha.1015.0",
+        "@ew-did-registry/revocation": "0.8.1-alpha.1015.0",
+        "ethers": "^5.7.2",
         "ipfs-http-client": "^43.0.0",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@ew-did-registry/claims": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/claims/-/claims-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-/4fDEsoOOU9oCSi/zsuBOWOJnQokdWuE3ntNeGsCNJcLsawxYcHCSaYjN6BqSaCOvsd+cR9OIDG5gc5ZqbVclA==",
+          "requires": {
+            "@ew-did-registry/credentials-interface": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-document": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-ipfs-store": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-store-interface": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/jwt": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+            "@types/sjcl": "1.0.28",
+            "base64url": "^3.0.1",
+            "eciesjs": "^0.3.4",
+            "ethers": "^5.7.2",
+            "sjcl": "npm:sjcl-complete@1.0.0"
+          },
+          "dependencies": {
+            "@ew-did-registry/did-ipfs-store": {
+              "version": "0.8.1-alpha.1015.0",
+              "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ipfs-store/-/did-ipfs-store-0.8.1-alpha.1015.0.tgz",
+              "integrity": "sha512-xKubaflwDF/2bUwoJgbhDRcb0lRHk44iEjP00Ub6OQ22NwbKPsHFwX/VJiZqOxi+FQu+LISgiE6ISrbbHa54wg==",
+              "requires": {
+                "@ew-did-registry/did-store-interface": "0.8.1-alpha.1015.0",
+                "@web-std/fetch": "^4.1.0",
+                "@web-std/file": "^3.0.2",
+                "@web-std/form-data": "^3.0.2",
+                "axios": "^0.27.2"
+              }
+            }
+          }
+        },
+        "@ew-did-registry/credentials-interface": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/credentials-interface/-/credentials-interface-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-ZRQhKJXBe+FP8q2aICmdEtz1fUe25HgrHDWc3+BsneNx6vGpmhGNpCotVkLBdMppdeN+yCl2izqSSX1K6J5AoQ==",
+          "requires": {
+            "@sphereon/pex": "1.1.3",
+            "@types/lodash": "^4.14.181",
+            "joi": "^17.6.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@ew-did-registry/did": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-bupVwCH9EYM/qpbZGMzacFNslA0Ng5aFrmsXLVmuJMJRHOx4zbsA+Y3XaGmPF9v7d9Gyr58gLREBeACvksqkpg=="
+        },
+        "@ew-did-registry/did-document": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-document/-/did-document-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-SZVxaA52LcdSDVIAHDmQ4YXjHGWISmnXu1iGwkydTg98g/Sc7QDTGSYN5hwMTwJ3pqOsWFqgZLuX2CyDix9JTQ==",
+          "requires": {
+            "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-ethr-resolver": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+            "ethers": "^5.7.2"
+          }
+        },
+        "@ew-did-registry/did-ethr-resolver": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-jNkWgR12bRh8LJ6OUOOnsfw+OSTJFG7N6BMwwV4Fw576W3NDid3zzZYD2HI2LXDUS2D3BMiPaLy6gdq0nNzazA==",
+          "requires": {
+            "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+            "ethers": "^5.7.2"
+          }
+        },
+        "@ew-did-registry/did-resolver-interface": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-GHjzVhI1MacVkpNd0/tFVX7wGyvSpBGW4i2FLswpteEGd6tAW/q8h28EyutmgnIZ3YBn7Bz5Xxi8a3Ans63t6Q==",
+          "requires": {
+            "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+            "ethers": "^5.7.2"
+          }
+        },
+        "@ew-did-registry/did-store-interface": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/did-store-interface/-/did-store-interface-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-oiyXUR16D9FHaC3OBx9QOWJkUTsdvE5mIwyeJWUyP+aYkDxJQpTE4rGKSu1XOm9zu/S8KnFR7T9mLAQupHlmJg=="
+        },
+        "@ew-did-registry/jwt": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/jwt/-/jwt-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-XnPeBDxlD0wiLSzXpoLGf5oDgjB5gUb/j3uxOKgAq3dQqVWoVOLaamf85JYmiTYmvhfIDq/8nG14UVEaXjgKaw==",
+          "requires": {
+            "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+            "base64url": "^3.0.1",
+            "ec-key": "0.0.4",
+            "ethereumjs-util": "^7.0.5",
+            "ethers": "^5.7.2",
+            "jsonwebtoken": "^8.5.1",
+            "promise.allsettled": "^1.0.2"
+          }
+        },
+        "@ew-did-registry/keys": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-sKkkcnj66znSWayMr5O4U+t59jCwVg5iJVe3w6EzKLuraJCA0stS2tYh35/CbOtVJAMf/JBiEEIKn5j2RAtXgw==",
+          "requires": {
+            "bn.js": "5.2.0",
+            "ec-key": "0.0.4",
+            "eciesjs": "^0.3.4",
+            "elliptic": "^6.5.2",
+            "ethers": "^5.7.2",
+            "key-encoder": "^2.0.3"
+          }
+        },
+        "@ew-did-registry/revocation": {
+          "version": "0.8.1-alpha.1015.0",
+          "resolved": "https://registry.npmjs.org/@ew-did-registry/revocation/-/revocation-0.8.1-alpha.1015.0.tgz",
+          "integrity": "sha512-993J/X5Tmbg+DUu+yowwwXDzmRlm6Z0FQi5WLZytrIPaS1zxs87tVa+PHBBFsXng4kYqRXJ4Lc90j8jzqHxNKg==",
+          "requires": {
+            "@ew-did-registry/credentials-interface": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/did-ethr-resolver": "0.6.0",
+            "@ew-did-registry/did-resolver-interface": "0.8.1-alpha.1015.0",
+            "@ew-did-registry/keys": "0.8.1-alpha.1015.0",
+            "axios": "^0.27.2",
+            "didkit-wasm-node": "^0.1.6",
+            "ethers": "^5.7.2"
+          },
+          "dependencies": {
+            "@ew-did-registry/did-ethr-resolver": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/@ew-did-registry/did-ethr-resolver/-/did-ethr-resolver-0.6.0.tgz",
+              "integrity": "sha512-cwByi6Ic43vm+l7TyBY4auN5tg45HjAdHGitWn+ZH25qZRBajcaizCjPekai+kAU4DNJVis/XqsmYP1NtIagRA==",
+              "requires": {
+                "@ew-did-registry/did": "0.6.0",
+                "@ew-did-registry/did-resolver-interface": "0.6.0",
+                "@ew-did-registry/keys": "0.6.0",
+                "ethers": "^5.4.6"
+              },
+              "dependencies": {
+                "@ew-did-registry/did": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/@ew-did-registry/did/-/did-0.6.0.tgz",
+                  "integrity": "sha512-GOvIDdu5giS3I8E+mhOMzHXNu1mq1VXAT3NPchOHslVcI1LVLgtgXIfudoAMleL/XjVhSb18JoPKboGGGzRG8A=="
+                },
+                "@ew-did-registry/did-resolver-interface": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/@ew-did-registry/did-resolver-interface/-/did-resolver-interface-0.6.0.tgz",
+                  "integrity": "sha512-UKmoCW51Y98ddT0mlfCUfEWnM7v1IzFKFFXi2aNvhd6NvmCE91KoaUuEivaYoG4LtT/xIJus18n/EWsTQXZRyA==",
+                  "requires": {
+                    "@ew-did-registry/did": "0.6.0",
+                    "ethers": "^5.4.6"
+                  }
+                },
+                "@ew-did-registry/keys": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/@ew-did-registry/keys/-/keys-0.6.0.tgz",
+                  "integrity": "sha512-mHO6ao2FnVlazOsbNwdViEtafbMMG0iShxOqqr6dgSRuBwz9lV0I70PYfj6UlHIvYP6T0KwlIbXMx8oZYw/XbQ==",
+                  "requires": {
+                    "bn.js": "5.2.0",
+                    "eciesjs": "^0.3.4",
+                    "elliptic": "^6.5.2",
+                    "ethers": "^5.4.6"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        }
       }
     },
     "@ensdomains/ens": {
@@ -37097,9 +37569,9 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.1.tgz",
-      "integrity": "sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -44309,9 +44781,9 @@
       }
     },
     "ethers": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.1.tgz",
-      "integrity": "sha512-5krze4dRLITX7FpU8J4WscXqADiKmyeNlylmmDLbS95DaZpBhDe2YSwRQwKXWNyXcox7a3gBgm/MkGXV1O1S/Q==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "requires": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/abstract-provider": "5.7.0",
@@ -44331,7 +44803,7 @@
         "@ethersproject/networks": "5.7.1",
         "@ethersproject/pbkdf2": "5.7.0",
         "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.1",
+        "@ethersproject/providers": "5.7.2",
         "@ethersproject/random": "5.7.0",
         "@ethersproject/rlp": "5.7.0",
         "@ethersproject/sha2": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
     "npm": ">= 6.0.0"
   },
   "dependencies": {
-    "@energyweb/credential-governance": "2.2.1-alpha.310.0",
+    "@energyweb/credential-governance": "2.2.1-alpha.312.0",
     "@energyweb/ekc": "^0.6.7",
-    "@energyweb/onchain-claims": "2.2.1-alpha.310.0",
+    "@energyweb/onchain-claims": "2.2.1-alpha.312.0",
     "@energyweb/staking-pool": "^1.0.0-rc.14",
-    "@energyweb/vc-verification": "2.2.1-alpha.310.0",
+    "@energyweb/vc-verification": "2.2.1-alpha.312.0",
     "@ensdomains/ens": "^0.6.2",
     "@ew-did-registry/claims": "0.8.1-alpha.996.0",
     "@ew-did-registry/credentials-interface": "0.8.1-alpha.996.0",


### PR DESCRIPTION
### Description

Updates ew-credentials packages to 2.2.1-alpha.312 . Needed to have `schema` prop available in `FieldDefinition`.

I didn't add a test for `schema` functionality as we don't have test coverage yet for different `FieldDefinitions` as far as I can tell

Relates to https://github.com/energywebfoundation/ssi-hub/pull/554

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
