### PR TITLE
bug: missing /v1 in Siwe uri

### DIFF
--- a/src/modules/cache-client/auth.ts
+++ b/src/modules/cache-client/auth.ts
@@ -30,8 +30,8 @@ export class SsiAuth {
       data: { nonce },
     } = await this.http.post<{ nonce: string }>('/login/siwe/initiate');
     const uri = new URL(
-      '/login/siwe/verify',
-      cacheConfigs()[this.signerService.chainId].url
+      '/v1/login/siwe/verify',
+      new URL(cacheConfigs()[this.signerService.chainId].url).origin
     ).href;
     const siweMessage = new SiweMessage({
       nonce,


### PR DESCRIPTION
### Description

Fixes missing `/v1` in default Siwe uri
![image](https://user-images.githubusercontent.com/44746858/221169178-d505fef0-9c6d-4a76-85ea-f932c0fa8930.png)


<!-- PUT YOUR TASK DESCRIPTION HERE -->

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
