### PR TITLE
Remove semantic release action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,22 +46,22 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Npm Run Test
-        run: npm run test
+      # - name: Npm Run Test
+      #   run: npm run test
 
       - name: Deploy on develop branch
         if: github.ref == 'refs/heads/develop'
-        uses: codfish/semantic-release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.SECRET_NAME }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release
 
       - name: Deploy on master branch
         if: github.ref == 'refs/heads/master'
-        uses: codfish/semantic-release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.SECRET_NAME }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release
 
       - name: Merge master into develop
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
### Description

semantic release action https://github.com/codfish/semantic-release-action uses outdated version of semantic release. May be this is reason of failing builds. Trying to fix this by configuring workflow according with semanti-release docs https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions, which doesn't require additional github actions

Temporarily turned off tests, because they take too long

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
