### PR TITLE
Bundle tslib

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ module.exports = [
         tsconfig: 'tsconfig.build.json',
       }),
     ],
-    external: [/node_modules/],
+    external: [/node_modules(?!\/tslib)/],
   },
   {
     input: 'src/index.ts',
@@ -36,6 +36,6 @@ module.exports = [
         tsconfig: 'tsconfig.build.json',
       }),
     ],
-    external: [/node_modules/],
+    external: [/node_modules(?!\/tslib)/],
   },
 ];


### PR DESCRIPTION
### Description

This is temporal fix for issue with `rollup`. The issue is that `rollup` importing `tslib` as local dependency like this
```
import { __awaiter } from '/home/runner/work/iam-client-lib/iam-client-lib/node_modules/tslib/tslib.es6.js'
```
This PR temporarily excludes `tslib` from external dependencies and bundles it

We also does not directly import `tslib`, so there is no need to add to package.json https://github.com/energywebfoundation/iam-client-lib/blob/9df32764c2d5036a5be2d82ecfa7c916c7386582/package.json#L107

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
