### PR TITLE
Fix claim expiration timestamp

### DIFF
--- a/docs/api/classes/modules_signer.SignerService.md
+++ b/docs/api/classes/modules_signer.SignerService.md
@@ -353,13 +353,13 @@ ___
 
 Add event handler for certain events
 
-**`Requires`**
-
-to be called after the connection to wallet was initialized
-
 #### Returns
 
 `void`
+
+**`Requires`**
+
+to be called after the connection to wallet was initialized
 
 ___
 

--- a/docs/api/classes/modules_staking.StakingFactoryService.md
+++ b/docs/api/classes/modules_staking.StakingFactoryService.md
@@ -35,13 +35,13 @@ Intended for staking pool
 
 ▸ **allServices**(): `Promise`<[`Service`](../modules/modules_staking.md#service)[]\>
 
-**`Description`**
-
-Returns all services for which pools are launched
-
 #### Returns
 
 `Promise`<[`Service`](../modules/modules_staking.md#service)[]\>
+
+**`Description`**
+
+Returns all services for which pools are launched
 
 ___
 
@@ -49,13 +49,13 @@ ___
 
 ▸ **getPool**(): `Promise`<[`StakingPoolService`](modules_staking.StakingPoolService.md)\>
 
-**`Description`**
-
-Returns pool launched for energyweb org
-
 #### Returns
 
 `Promise`<[`StakingPoolService`](modules_staking.StakingPoolService.md)\>
+
+**`Description`**
+
+Returns pool launched for energyweb org
 
 ___
 

--- a/docs/api/classes/modules_staking.StakingPoolService.md
+++ b/docs/api/classes/modules_staking.StakingPoolService.md
@@ -127,8 +127,6 @@ ___
 
 ▸ **partialWithdraw**(`value`): `Promise`<`ContractReceipt`\>
 
-**`Description`**
-
 #### Parameters
 
 | Name | Type |
@@ -139,19 +137,13 @@ ___
 
 `Promise`<`ContractReceipt`\>
 
+**`Description`**
+
 ___
 
 ### putStake
 
 ▸ **putStake**(`stake`): `Promise`<`void`\>
-
-**`Description`**
-
-Locks stake and starts accumulating reward
-
-**`Emits`**
-
-StakingPool.StakePut
 
 #### Parameters
 
@@ -163,16 +155,24 @@ StakingPool.StakePut
 
 `Promise`<`void`\>
 
+**`Description`**
+
+Locks stake and starts accumulating reward
+
+**`Emits`**
+
+StakingPool.StakePut
+
 ___
 
 ### withdraw
 
 ▸ **withdraw**(): `Promise`<`void`\>
 
-**`Description`**
-
-pays back stake with accumulated reward.
-
 #### Returns
 
 `Promise`<`void`\>
+
+**`Description`**
+
+pays back stake with accumulated reward.

--- a/docs/api/classes/modules_verifiable_credentials.VerifiableCredentialsServiceBase.md
+++ b/docs/api/classes/modules_verifiable_credentials.VerifiableCredentialsServiceBase.md
@@ -50,10 +50,6 @@ verifiableCredentialsService.createRoleVC(...);
 
 ▸ **continueExchange**(`«destructured»`): `Promise`<`undefined` \| `VerifiablePresentation` \| `VpRequest`\>
 
-**`Description`**
-
-Sends credentials requested by issuer and returns either issued credentials or next credentials request
-
 #### Parameters
 
 | Name | Type |
@@ -65,6 +61,10 @@ Sends credentials requested by issuer and returns either issued credentials or n
 `Promise`<`undefined` \| `VerifiablePresentation` \| `VpRequest`\>
 
 issued credentials or request of additional credentials
+
+**`Description`**
+
+Sends credentials requested by issuer and returns either issued credentials or next credentials request
 
 ___
 

--- a/docs/api/interfaces/modules_claims.Claim.md
+++ b/docs/api/interfaces/modules_claims.Claim.md
@@ -60,7 +60,7 @@ ___
 
 ### expirationTimestamp
 
-• `Optional` **expirationTimestamp**: `string`
+• `Optional` **expirationTimestamp**: `number`
 
 ___
 

--- a/docs/api/modules/modules_signer.md
+++ b/docs/api/modules/modules_signer.md
@@ -106,11 +106,6 @@ ___
 
 ▸ **fromGnosis**(`safeAppSdk`): `Promise`<[`SignerService`](../classes/modules_signer.SignerService.md)\>
 
-**`Description`**
-
-Intended for use in Volta Gnosis web interface(https://volta.gnosis-safe.io/).
-Dapp should provide SafeAppSdk injected by Gnosis interface
-
 #### Parameters
 
 | Name | Type |
@@ -120,6 +115,11 @@ Dapp should provide SafeAppSdk injected by Gnosis interface
 #### Returns
 
 `Promise`<[`SignerService`](../classes/modules_signer.SignerService.md)\>
+
+**`Description`**
+
+Intended for use in Volta Gnosis web interface(https://volta.gnosis-safe.io/).
+Dapp should provide SafeAppSdk injected by Gnosis interface
 
 ___
 

--- a/src/modules/claims/claims.service.ts
+++ b/src/modules/claims/claims.service.ts
@@ -793,7 +793,7 @@ export class ClaimsService {
         throw new Error(ERROR_MESSAGES.PUBLISH_NOT_ISSUED_CLAIM);
       }
       const expirationTimestamp = claimDataForClaimType.expirationTimestamp
-        ? Math.floor(+claimDataForClaimType.expirationTimestamp / 1000)
+        ? Math.floor(claimDataForClaimType.expirationTimestamp / 1000)
         : undefined;
 
       await this.registerOnchain({

--- a/src/modules/claims/claims.types.ts
+++ b/src/modules/claims/claims.types.ts
@@ -69,7 +69,7 @@ export interface Claim {
   createdAt: string;
   redirectUri?: string;
   vp?: VerifiablePresentation;
-  expirationTimestamp?: string;
+  expirationTimestamp?: number;
 }
 
 export const readyToBeRegisteredOnchain = (


### PR DESCRIPTION
### Description

Claim expiration timestamp is defined as string though in fact it is number https://github.com/energywebfoundation/ssi-hub/blob/291ab134d182a9fb658fbe56d469172f23840711/src/modules/claim/entities/roleClaim.entity.ts#L101
This fix is not a breaking change, because `expirationTimestamp` anyways converted to number in the only place where it is used https://github.com/energywebfoundation/iam-client-lib/blob/6db25b741f79ba642688a39180afcdf86b071e8c/src/modules/claims/claims.service.ts#L796

### Contributor checklist

- [x] Breaking changes - check for any existing interfaces changes that are not backward compatible, removed method etc.
- [x] Documentation - document your code, add comments for method, remember to check if auto generated docs were updated.
- [x] Tests - add new or updated existed test for changes you made.
- [x] Migration guide - add migration guide for every breaking change.
- [x] Configuration correctness - check that any configuration changes are correct ex. default URLs, chain ids, smart contract verification on [Volta explorer](https://volta-explorer.energyweb.org/) or [EWC explorer](https://explorer.energyweb.org/).
